### PR TITLE
Fix: SetSpellByID -> SetHyperlink(GetSpellLink(ID))

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3886,7 +3886,8 @@ function GenericTrigger.SetToolTip(trigger, state)
       end
       return true
     elseif (state.spellId) then
-      GameTooltip:SetSpellByID(state.spellId);
+      --DEPRECATED GameTooltip:SetSpellByID(state.spellId);
+      GameTooltip:SetHyperlink(GetSpellLink(state.spellId));
       return true
     elseif (state.link) then
       GameTooltip:SetHyperlink(state.link);
@@ -3909,7 +3910,9 @@ function GenericTrigger.SetToolTip(trigger, state)
   local prototype = GenericTrigger.GetPrototype(trigger)
   if prototype then
     if prototype.hasSpellID then
-      GameTooltip:SetSpellByID(trigger.spellName or 0);
+      --DEPRECATED GameTooltip:SetSpellByID(trigger.spellName or 0);
+      local SetSpellByID = GetSpellLink(trigger.spellName)
+      GameTooltip:SetHyperlink(SetSpellByID or "")
       return true
     elseif prototype.hasItemID then
       GameTooltip:SetHyperlink("item:"..(trigger.itemName or 0)..":0:0:0:0:0:0:0")

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasMiniTalent_Wrath.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasMiniTalent_Wrath.lua
@@ -93,7 +93,8 @@ end
 local function Button_ShowToolTip(self)
   if self.spellId then
     GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-    GameTooltip:SetSpellByID(self.spellId)
+    --DEPRECATED GameTooltip:SetSpellByID(self.spellId)
+    GameTooltip:SetHyperlink(GetSpellLink(self.spellId));
   end
 end
 local function Button_HideToolTip(self)


### PR DESCRIPTION
This is a fix for GameTooltip for Spells. In 3.3.5 API, ``GameTooltip:SetSpellByID`` only allows player known spells to be set — workaround for this is using ``GameTooltip:SetHyperlink(GetSpellLink())`` allowing for any spell, even those unknown to be set.


## Changes
- Replace deprecated `GameTooltip:SetSpellByID()` with `GameTooltip:SetHyperlink(GetSpellLink())` 
- Updated tooltip handling in GenericTrigger.lua and WeakAurasMiniTalent_Wrath.lua
- Added comments marking the old method as deprecated so that they are still searchable.

## Testing
- Verified tooltips still display correctly for:
  - Generic triggers with spell IDs
  - State-based spell tooltips
- Unable to test (Requires testing before merge)
  - Talent buttons in the WeakAuras options UI