### PR TITLE
Fix: SetSpellByID -> Hardcoded Spell Escape Sequence strings

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3887,7 +3887,7 @@ function GenericTrigger.SetToolTip(trigger, state)
       return true
     elseif (state.spellId) then
       --DEPRECATED GameTooltip:SetSpellByID(state.spellId);
-      GameTooltip:SetHyperlink("|Hspell:"..(state.spellId or 0).."|h|h");
+      GameTooltip:SetHyperlink("spell:"..(state.spellId or 0));
       return true
     elseif (state.link) then
       GameTooltip:SetHyperlink(state.link);
@@ -3911,7 +3911,7 @@ function GenericTrigger.SetToolTip(trigger, state)
   if prototype then
     if prototype.hasSpellID then
       --DEPRECATED GameTooltip:SetSpellByID(trigger.spellName or 0);
-      GameTooltip:SetHyperlink("|Hspell:"..(trigger.spellName or 0).."|h|h");
+      GameTooltip:SetHyperlink("spell:"..(trigger.spellName or 0));
       return true
     elseif prototype.hasItemID then
       GameTooltip:SetHyperlink("item:"..(trigger.itemName or 0)..":0:0:0:0:0:0:0")

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3886,7 +3886,8 @@ function GenericTrigger.SetToolTip(trigger, state)
       end
       return true
     elseif (state.spellId) then
-      GameTooltip:SetSpellByID(state.spellId);
+      --DEPRECATED GameTooltip:SetSpellByID(state.spellId);
+      GameTooltip:SetHyperlink(GetSpellLink(state.spellId));
       return true
     elseif (state.link) then
       GameTooltip:SetHyperlink(state.link);
@@ -3909,7 +3910,9 @@ function GenericTrigger.SetToolTip(trigger, state)
   local prototype = GenericTrigger.GetPrototype(trigger)
   if prototype then
     if prototype.hasSpellID then
-      GameTooltip:SetSpellByID(trigger.spellName or 0);
+      --DEPRECATED GameTooltip:SetSpellByID(trigger.spellName or 0);
+      local SetSpellByID = GetSpellLink(trigger.spellName)
+      GameTooltip:SetHyperlink(SetSpellByID or "")
       return true
     elseif prototype.hasItemID then
       GameTooltip:SetHyperlink("item:"..(trigger.itemName or 0)..":0:0:0:0:0:0:0")

--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3887,7 +3887,7 @@ function GenericTrigger.SetToolTip(trigger, state)
       return true
     elseif (state.spellId) then
       --DEPRECATED GameTooltip:SetSpellByID(state.spellId);
-      GameTooltip:SetHyperlink(GetSpellLink(state.spellId));
+      GameTooltip:SetHyperlink("|Hspell:"..(state.spellId or 0).."|h|h");
       return true
     elseif (state.link) then
       GameTooltip:SetHyperlink(state.link);
@@ -3911,8 +3911,7 @@ function GenericTrigger.SetToolTip(trigger, state)
   if prototype then
     if prototype.hasSpellID then
       --DEPRECATED GameTooltip:SetSpellByID(trigger.spellName or 0);
-      local SetSpellByID = GetSpellLink(trigger.spellName)
-      GameTooltip:SetHyperlink(SetSpellByID or "")
+      GameTooltip:SetHyperlink("|Hspell:"..(trigger.spellName or 0).."|h|h");
       return true
     elseif prototype.hasItemID then
       GameTooltip:SetHyperlink("item:"..(trigger.itemName or 0)..":0:0:0:0:0:0:0")

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasMiniTalent_Wrath.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasMiniTalent_Wrath.lua
@@ -93,7 +93,8 @@ end
 local function Button_ShowToolTip(self)
   if self.spellId then
     GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-    GameTooltip:SetSpellByID(self.spellId)
+    --DEPRECATED GameTooltip:SetSpellByID(self.spellId)
+    GameTooltip:SetHyperlink(GetSpellLink(self.spellId));
   end
 end
 local function Button_HideToolTip(self)

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasMiniTalent_Wrath.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasMiniTalent_Wrath.lua
@@ -94,7 +94,7 @@ local function Button_ShowToolTip(self)
   if self.spellId then
     GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
     --DEPRECATED GameTooltip:SetSpellByID(self.spellId)
-    GameTooltip:SetHyperlink(GetSpellLink(self.spellId));
+    GameTooltip:SetHyperlink("|Hspell:"..(self.spellId or 0).."|h|h")
   end
 end
 local function Button_HideToolTip(self)

--- a/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasMiniTalent_Wrath.lua
+++ b/WeakAurasOptions/AceGUI-Widgets/AceGUIWidget-WeakAurasMiniTalent_Wrath.lua
@@ -94,7 +94,7 @@ local function Button_ShowToolTip(self)
   if self.spellId then
     GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
     --DEPRECATED GameTooltip:SetSpellByID(self.spellId)
-    GameTooltip:SetHyperlink("|Hspell:"..(self.spellId or 0).."|h|h")
+    GameTooltip:SetHyperlink("spell:"..(self.spellId or 0))
   end
 end
 local function Button_HideToolTip(self)


### PR DESCRIPTION
As outlined in #23 but now properly implemented – this is a fix for GameTooltip for Spells. In 3.3.5 API, ``GameTooltip:SetSpellByID`` only allows player known spells to be set. The workaround for this is using ``GameTooltip:SetHyperlink()`` and hardcoding an escape sequence for spells.

Initially the full escape sequence was used (e.g. ``GameTooltip:SetHyperlink("|Hspell:"..(trigger.spellName or 0).."|h|h");``. However, as many of the characters are redundant for enclosed strings. We can drop those for readability sake — as was done in #6702d41. As such, I suggest a merge (when done) to be a squash.

## Changes
- Replace deprecated `GameTooltip:SetSpellByID()` with `GameTooltip:SetHyperlink("spell:"..(spellId or 0))`
  - or 0 here allows for nil checking and hides the tooltip upon a nil spellId
- Updated tooltip handling in GenericTrigger.lua and WeakAurasMiniTalent_Wrath.lua
- Added comments marking the old method as deprecated so that they are still searchable.

## Testing
- Verified tooltips still display correctly for:
  - Generic triggers with spell IDs (prototypes)
  - State-based spell tooltips
  - Talent buttons in the WeakAuras options UI
  
 No lua errors encountered for this implementation as of yet.