### PR TITLE
Introduce sub elements for circular/linear Textures

### DIFF
--- a/WeakAuras/BaseRegions/CircularProgressTexture.lua
+++ b/WeakAuras/BaseRegions/CircularProgressTexture.lua
@@ -1,0 +1,221 @@
+if not WeakAuras.IsLibsOK() then return end
+
+local AddonName = ...
+local Private = select(2, ...)
+
+local L = WeakAuras.L
+
+Private.CircularProgressTextureBase = {}
+
+local funcs = {
+  SetAuraRotation = function (self, radians)
+    for i = 1, 3 do
+      self.textures[i]:SetRotation(radians)
+    end
+  end,
+  SetTextureOrAtlas = function(self, texture)
+    for i = 1, 3 do
+      self.textures[i]:SetTexture(texture)
+    end
+  end,
+  SetDesaturated = function(self, desaturate)
+    for i = 1, 3 do
+      self.textures[i]:SetDesaturated(desaturate)
+    end
+  end,
+  SetBlendMode = function(self, blendMode)
+    for i = 1, 3 do
+      self.textures[i]:SetBlendMode(blendMode)
+    end
+  end,
+  Show = function(self)
+    self.visible = true
+    for i = 1, 3 do
+      self.textures[i]:Show()
+    end
+  end,
+  Hide = function(self)
+    self.visible = false
+    for i = 1, 3 do
+      self.textures[i]:Hide()
+    end
+  end,
+  SetColor = function (self, r, g, b, a)
+    for i = 1, 3 do
+      self.textures[i]:SetVertexColor(r, g, b, a)
+    end
+  end,
+  SetCropX = function(self, crop_x)
+    self.crop_x = crop_x
+    self:UpdateTextures()
+  end,
+  SetCropY = function(self, crop_y)
+    self.crop_y = crop_y
+    self:UpdateTextures()
+  end,
+  SetTexRotation = function(self, texRotation)
+    self.texRotation = texRotation
+    self:UpdateTextures()
+  end,
+  SetMirrorHV = function(self, mirror_h, mirror_v)
+    self.mirror_h = mirror_h
+    self.mirror_v = mirror_v
+  end,
+  SetMirror = function(self, mirror)
+    self.mirror = mirror
+    self:UpdateTextures()
+  end,
+  SetWidth = function(self, width)
+    self.width = width
+  end,
+  SetHeight = function(self, height)
+    self.height = height
+  end,
+  SetScale = function(self, scalex, scaley)
+    self.scalex, self.scaley = scalex, scaley
+  end,
+  UpdateTextures = function(self)
+    if not self.visible then
+      return
+    end
+    local crop_x = self.crop_x or 1
+    local crop_y = self.crop_y or 1
+    local texRotation = self.texRotation or 0
+    local mirror_h = self.mirror_h or false
+    if self.mirror then
+      mirror_h = not mirror_h
+    end
+    local mirror_v = self.mirror_v or false
+
+    local width = self.width * (self.scalex or 1) + 2 * self.offset
+    local height = self.height * (self.scaley or 1) + 2 * self.offset
+
+    if width == 0 or height == 0 then
+      return
+    end
+
+    local angle1 = self.angle1
+    local angle2 = self.angle2
+
+    if angle1 == nil or angle2 == nil then
+      return
+    end
+
+    if (angle2 - angle1 >= 360) then
+      -- SHOW everything
+      self.coords[1]:SetFull()
+      self.coords[1]:Transform(crop_x, crop_y, texRotation, mirror_h, mirror_v)
+      self.coords[1]:Show()
+
+      self.coords[2]:Hide()
+      self.coords[3]:Hide()
+      return
+    end
+    if (angle1 == angle2) then
+      self.coords[1]:Hide()
+      self.coords[2]:Hide()
+      self.coords[3]:Hide()
+      return
+    end
+
+    local index1 = floor((angle1 + 45) / 90)
+    local index2 = floor((angle2 + 45) / 90)
+
+    if (index1 + 1 >= index2) then
+      self.coords[1]:SetAngle(width, height, angle1, angle2)
+      self.coords[1]:Transform(crop_x, crop_y, texRotation, mirror_h, mirror_v)
+      self.coords[1]:Show()
+      self.coords[2]:Hide()
+      self.coords[3]:Hide()
+    elseif(index1 + 3 >= index2) then
+      local firstEndAngle = (index1 + 1) * 90 + 45
+      self.coords[1]:SetAngle(width, height, angle1, firstEndAngle)
+      self.coords[1]:Transform(crop_x, crop_y, texRotation, mirror_h, mirror_v)
+      self.coords[1]:Show()
+
+      self.coords[2]:SetAngle(width, height, firstEndAngle, angle2)
+      self.coords[2]:Transform(crop_x, crop_y, texRotation, mirror_h, mirror_v)
+      self.coords[2]:Show()
+
+      self.coords[3]:Hide()
+    else
+      local firstEndAngle = (index1 + 1) * 90 + 45
+      local secondEndAngle = firstEndAngle + 180
+
+      self.coords[1]:SetAngle(width, height, angle1, firstEndAngle)
+      self.coords[1]:Transform(crop_x, crop_y, texRotation, mirror_h, mirror_v)
+      self.coords[1]:Show()
+
+      self.coords[2]:SetAngle(width, height, firstEndAngle, secondEndAngle)
+      self.coords[2]:Transform(crop_x, crop_y, texRotation, mirror_h, mirror_v)
+      self.coords[2]:Show()
+
+      self.coords[3]:SetAngle(width, height, secondEndAngle, angle2)
+      self.coords[3]:Transform(crop_x, crop_y, texRotation, mirror_h, mirror_v)
+      self.coords[3]:Show()
+    end
+  end,
+  SetProgress = function (self, angle1, angle2)
+    self.angle1 = angle1
+    self.angle2 = angle2
+    self:UpdateTextures()
+  end,
+}
+
+function Private.CircularProgressTextureBase.create(frame, layer, drawLayer)
+  local circularTexture = {}
+
+  circularTexture.textures = {}
+  circularTexture.coords = {}
+  circularTexture.offset = 0
+  circularTexture.visible = true
+
+  for i = 1, 3 do
+    local texture = frame:CreateTexture(nil, layer)
+    texture:SetDrawLayer(layer, drawLayer)
+    texture:SetAllPoints(frame)
+    circularTexture.textures[i] = texture
+
+    circularTexture.coords[i] = Private.TextureCoords.create(texture)
+  end
+
+  for funcName, func in pairs(funcs) do
+    circularTexture[funcName] = func
+  end
+
+  circularTexture.parentFrame = frame
+
+  return circularTexture
+end
+
+function Private.CircularProgressTextureBase.modify(circularTexture, options)
+  circularTexture:SetTextureOrAtlas(options.texture)
+  circularTexture:SetDesaturated(options.desaturated)
+  circularTexture:SetBlendMode(options.blendMode)
+  circularTexture:SetAuraRotation(options.auraRotation)
+  circularTexture.crop_x = options.crop_x
+  circularTexture.crop_y = options.crop_y
+  circularTexture.mirror = options.mirror
+  circularTexture.texRotation = options.texRotation
+  circularTexture.width = options.width
+  circularTexture.height = options.height
+  circularTexture.offset = options.offset
+  local offset = options.offset
+  local frame = circularTexture.parentFrame
+  if offset > 0 then
+    for i = 1, 3 do
+      circularTexture.textures[i]:ClearAllPoints()
+      circularTexture.textures[i]:SetPoint('TOPRIGHT', frame, offset, offset)
+      circularTexture.textures[i]:SetPoint('BOTTOMRIGHT', frame, offset, -offset)
+      circularTexture.textures[i]:SetPoint('BOTTOMLEFT', frame, -offset, -offset)
+      circularTexture.textures[i]:SetPoint('TOPLEFT', frame, -offset, offset)
+    end
+  else
+    for i = 1, 3 do
+      circularTexture.textures[i]:ClearAllPoints()
+      circularTexture.textures[i]:SetAllPoints(frame)
+    end
+  end
+
+  circularTexture:UpdateTextures()
+end

--- a/WeakAuras/BaseRegions/LinearProgressTexture.lua
+++ b/WeakAuras/BaseRegions/LinearProgressTexture.lua
@@ -1,0 +1,301 @@
+if not WeakAuras.IsLibsOK() then return end
+
+local AddonName = ...
+local Private = select(2, ...)
+
+local L = WeakAuras.L
+
+Private.LinearProgressTextureBase = {}
+
+local orientationToAnchorPoint = {
+  ["HORIZONTAL"] = "LEFT",
+  ["HORIZONTAL_INVERSE"] = "RIGHT",
+  ["VERTICAL"] = "BOTTOM",
+  ["VERTICAL_INVERSE"] = "TOP"
+}
+
+
+local funcs = {
+  ApplyProgressToCoordFunctions = {
+    ["HORIZONTAL"] = function(self, startProgress, endProgress)
+      self.coord:MoveCorner(self.width, self.height, "UL", startProgress, 0 )
+      self.coord:MoveCorner(self.width, self.height, "LL", startProgress, 1 )
+
+      self.coord:MoveCorner(self.width, self.height, "UR", endProgress, 0 )
+      self.coord:MoveCorner(self.width, self.height, "LR", endProgress, 1 )
+    end,
+    ["HORIZONTAL_INVERSE"] = function(self, startProgress, endProgress)
+      self.coord:MoveCorner(self.width, self.height, "UL", 1 - endProgress, 0 )
+      self.coord:MoveCorner(self.width, self.height, "LL", 1 - endProgress, 1 )
+
+      self.coord:MoveCorner(self.width, self.height, "UR", 1 - startProgress, 0 )
+      self.coord:MoveCorner(self.width, self.height, "LR", 1 - startProgress, 1 )
+    end,
+    ["VERTICAL"] = function(self, startProgress, endProgress)
+      self.coord:MoveCorner(self.width, self.height, "UL", 0, 1 - endProgress )
+      self.coord:MoveCorner(self.width, self.height, "UR", 1, 1 - endProgress )
+
+      self.coord:MoveCorner(self.width, self.height, "LL", 0, 1 - startProgress )
+      self.coord:MoveCorner(self.width, self.height, "LR", 1, 1 - startProgress )
+    end,
+    ["VERTICAL_INVERSE"] = function(self, startProgress, endProgress)
+      self.coord:MoveCorner(self.width, self.height, "UL", 0, startProgress )
+      self.coord:MoveCorner(self.width, self.height, "UR", 1, startProgress )
+
+      self.coord:MoveCorner(self.width, self.height, "LL", 0, endProgress )
+      self.coord:MoveCorner(self.width, self.height, "LR", 1, endProgress )
+    end,
+  },
+
+  ApplyProgressToCoordFunctionsSlanted = {
+    ["HORIZONTAL"] = function(self, startProgress, endProgress)
+      local slant = self.slant or 0
+      if (self.slantMode == "EXTEND") then
+        startProgress = startProgress * (1 + slant) - slant
+        endProgress = endProgress * (1 + slant) - slant
+      else
+        startProgress = startProgress * (1 - slant)
+        endProgress = endProgress * (1 -  slant)
+      end
+
+      local slant1 = self.slantFirst and 0 or slant
+      local slant2 = self.slantFirst and slant or 0
+
+      self.coord:MoveCorner(self.width, self.height, "UL", startProgress + slant1, 0 )
+      self.coord:MoveCorner(self.width, self.height, "LL", startProgress + slant2, 1 )
+
+      self.coord:MoveCorner(self.width, self.height, "UR", endProgress + slant1, 0 )
+      self.coord:MoveCorner(self.width, self.height, "LR", endProgress + slant2, 1 )
+    end,
+    ["HORIZONTAL_INVERSE"] = function(self, startProgress, endProgress)
+      local slant = self.slant or 0
+      if (self.slantMode == "EXTEND") then
+        startProgress = startProgress * (1 + slant) - slant
+        endProgress = endProgress * (1 + slant) - slant
+      else
+        startProgress = startProgress * (1 - slant)
+        endProgress = endProgress * (1 -  slant)
+      end
+
+      local slant1 = self.slantFirst and slant or 0
+      local slant2 = self.slantFirst and 0 or slant
+
+      self.coord:MoveCorner(self.width, self.height, "UL", 1 - endProgress - slant1, 0 )
+      self.coord:MoveCorner(self.width, self.height, "LL", 1 - endProgress - slant2, 1 )
+
+      self.coord:MoveCorner(self.width, self.height, "UR", 1 - startProgress - slant1, 0 )
+      self.coord:MoveCorner(self.width, self.height, "LR", 1 - startProgress - slant2, 1 )
+    end,
+    ["VERTICAL"] = function(self, startProgress, endProgress)
+      local slant = self.slant or 0
+      if (self.slantMode == "EXTEND") then
+        startProgress = startProgress * (1 + slant) - slant
+        endProgress = endProgress * (1 + slant) - slant
+      else
+        startProgress = startProgress * (1 - slant)
+        endProgress = endProgress * (1 -  slant)
+      end
+
+      local slant1 = self.slantFirst and slant or 0
+      local slant2 = self.slantFirst and 0 or slant
+
+      self.coord:MoveCorner(self.width, self.height, "UL", 0, 1 - endProgress - slant1 )
+      self.coord:MoveCorner(self.width, self.height, "UR", 1, 1 - endProgress - slant2 )
+
+      self.coord:MoveCorner(self.width, self.height, "LL", 0, 1 - startProgress - slant1 )
+      self.coord:MoveCorner(self.width, self.height, "LR", 1, 1 - startProgress - slant2 )
+    end,
+    ["VERTICAL_INVERSE"] = function(self, startProgress, endProgress)
+      local slant = self.slant or 0
+      if (self.slantMode == "EXTEND") then
+        startProgress = startProgress * (1 + slant) - slant
+        endProgress = endProgress * (1 + slant) - slant
+      else
+        startProgress = startProgress * (1 - slant)
+        endProgress = endProgress * (1 -  slant)
+      end
+
+      local slant1 = self.slantFirst and 0 or slant
+      local slant2 = self.slantFirst and slant or 0
+
+      self.coord:MoveCorner(self.width, self.height, "UL", 0, startProgress + slant1 )
+      self.coord:MoveCorner(self.width, self.height, "UR", 1, startProgress + slant2 )
+
+      self.coord:MoveCorner(self.width, self.height, "LL", 0, endProgress + slant1 )
+      self.coord:MoveCorner(self.width, self.height, "LR", 1, endProgress + slant2 )
+    end,
+  },
+
+
+  SetOrientation = function(self, orientation, compress, slanted, slant, slantFirst, slantMode)
+    self.ApplyProgressToCoord = slanted and self.ApplyProgressToCoordFunctionsSlanted[orientation]
+                                or self.ApplyProgressToCoordFunctions[orientation]
+    self.compress = compress
+    self.slanted = slanted
+    self.slant = slant
+    self.slantFirst = slantFirst
+    self.slantMode = slantMode
+    if (self.compress) then
+      self.texture:ClearAllPoints()
+      local anchor = orientationToAnchorPoint[orientation]
+      self.texture:SetPoint(anchor, self.parentFrame, anchor)
+      self.horizontal = orientation == "HORIZONTAL" or orientation == "HORIZONTAL_INVERSE"
+    else
+      local offset = self.offset or 0
+      self.texture:ClearAllPoints()
+      self.texture:SetPoint("BOTTOMLEFT", self.parentFrame, "BOTTOMLEFT", -1 * offset, -1 * offset)
+      self.texture:SetPoint("TOPRIGHT", self.parentFrame, "TOPRIGHT", offset, offset)
+    end
+    self:Update()
+  end,
+
+  SetValue = function(self, startProgress, endProgress)
+    startProgress = Clamp(startProgress, 0, 1)
+    endProgress = Clamp(endProgress, 0, 1)
+    self.startProgress = startProgress
+    self.endProgress = endProgress
+
+    if (self.compress) then
+      -- Somewhat questionable usage of parentFrame.progress
+      local progress = self.parentFrame.progress or 1
+      local horScale = self.horizontal and progress or 1
+      local verScale = self.horizontal and 1 or progress
+      self:SetWidth(self.width * horScale)
+      self:SetHeight(self.height * verScale)
+
+      if (progress > 0.1) then
+        startProgress = startProgress / progress
+        endProgress = endProgress / progress
+      else
+        startProgress, endProgress = 0, 0
+      end
+    end
+    self:UpdateTextures()
+  end,
+
+  SetCropX = function(self, crop_x)
+    self.crop_x = crop_x
+    self:UpdateTextures()
+  end,
+  SetCropY = function(self, crop_y)
+    self.crop_y = crop_y
+    self:UpdateTextures()
+  end,
+  SetMirror = function(self, mirror)
+    self.mirror = mirror
+    self:UpdateTextures()
+  end,
+
+  SetMirrorHV = function(self, mirror_h, mirror_v)
+    self.mirror_h = mirror_h
+    self.mirror_v = mirror_v
+  end,
+
+
+  SetTexRotation = function(self, texRotation)
+    self.texRotation = texRotation
+    self:UpdateTextures()
+  end,
+
+  UpdateTextures = function(self)
+    if not self.visible or not self.ApplyProgressToCoord then
+      return
+    end
+    self.coord:SetFull()
+    self:ApplyProgressToCoord(self.startProgress, self.endProgress)
+    local crop_x = self.crop_x or 1
+    local crop_y = self.crop_y or 1
+    local texRotation = self.texRotation or 0
+    local mirror_h = self.mirror_h or false
+    if self.mirror then
+      mirror_h = not mirror_h
+    end
+    local mirror_v = self.mirror_v or false
+    local user_x = self.user_x
+    local user_y = self.user_y
+
+    self.coord:Transform(crop_x, crop_y, texRotation, mirror_h, mirror_v, user_x, user_y)
+    self.coord:Apply()
+  end,
+
+  Update = function(self)
+    self:SetValue(self.startProgress, self.endProgress)
+  end,
+
+  Show = function(self)
+    self.visible = true
+    self.texture:Show()
+  end,
+  Hide = function(self)
+    self.visible = false
+    self.texture:Hide()
+  end,
+
+  SetColor = function (self, r, g, b, a)
+    self.texture:SetVertexColor(r, g, b, a)
+  end,
+
+  GetBlendMode = function(self)
+    return self.texture:GetBlendMode()
+  end,
+
+  SetAuraRotation = function (self, radians)
+    self.texture:SetRotation(radians)
+  end,
+
+  SetTextureOrAtlas = function(self, texture)
+    self.texture:SetTexture(texture)
+  end,
+
+  SetDesaturated = function(self, desaturate)
+    self.texture:SetDesaturated(desaturate)
+  end,
+  SetBlendMode = function(self, blendMode)
+    self.texture:SetBlendMode(blendMode)
+  end,
+
+  SetWidth = function(self, width)
+    self.width = width
+  end,
+
+  SetHeight = function(self, height)
+    self.height = height
+  end,
+}
+
+function Private.LinearProgressTextureBase.create(frame, layer, drawLayer)
+  local linearTexture = {}
+  linearTexture.coords = {}
+  linearTexture.visible = true
+  linearTexture.parentFrame = frame
+  linearTexture.startProgress = 0
+  linearTexture.endProgress = 1
+
+  local texture = frame:CreateTexture(nil, layer)
+  texture:SetDrawLayer(layer, drawLayer)
+  linearTexture.texture = texture
+  linearTexture.coord  = Private.TextureCoords.create(texture)
+
+  for funcName, func in pairs(funcs) do
+    linearTexture[funcName] = func
+  end
+
+  return linearTexture
+end
+
+function Private.LinearProgressTextureBase.modify(linearTexture, options)
+  linearTexture:SetTextureOrAtlas(options.texture)
+  linearTexture:SetDesaturated(options.desaturated)
+  linearTexture:SetBlendMode(options.blendMode)
+  linearTexture:SetAuraRotation(options.auraRotation)
+  linearTexture.crop_x = options.crop_x
+  linearTexture.crop_y = options.crop_y
+  linearTexture.user_x = options.user_x
+  linearTexture.user_y = options.user_y
+  linearTexture.mirror = options.mirror
+  linearTexture.texRotation = options.texRotation
+  linearTexture.width = options.width
+  linearTexture.height = options.height
+  linearTexture.offset = options.offset
+  linearTexture:UpdateTextures()
+end

--- a/WeakAuras/BaseRegions/Texture.lua
+++ b/WeakAuras/BaseRegions/Texture.lua
@@ -118,7 +118,6 @@ function Private.TextureBase.modify(base, options)
   base.mirror = options.mirror
   base.rotation = options.rotation
   base.effectiveRotation = base.rotation
-  base.textureWrapMode = options.textureWrapMode
 
   base.texture:SetDesaturated(options.desaturate)
   base.texture:SetBlendMode(options.blendMode)

--- a/WeakAuras/BaseRegions/TextureCoords.lua
+++ b/WeakAuras/BaseRegions/TextureCoords.lua
@@ -134,10 +134,10 @@ local funcs = {
   end,
 
   Apply = function(self)
-    self.texture:SetVertexOffset(UPPER_RIGHT_VERTEX, self.URvx, self.URvy)
-    self.texture:SetVertexOffset(UPPER_LEFT_VERTEX, self.ULvx, self.ULvy)
-    self.texture:SetVertexOffset(LOWER_RIGHT_VERTEX, self.LRvx, self.LRvy)
-    self.texture:SetVertexOffset(LOWER_LEFT_VERTEX, self.LLvx, self.LLvy)
+    --self.texture:SetVertexOffset(UPPER_RIGHT_VERTEX, self.URvx, self.URvy)
+    --self.texture:SetVertexOffset(UPPER_LEFT_VERTEX, self.ULvx, self.ULvy)
+    --self.texture:SetVertexOffset(LOWER_RIGHT_VERTEX, self.LRvx, self.LRvy)
+    --self.texture:SetVertexOffset(LOWER_LEFT_VERTEX, self.LLvx, self.LLvy)
 
     self.texture:SetTexCoord(self.ULx, self.ULy, self.LLx, self.LLy, self.URx, self.URy, self.LRx, self.LRy)
   end,

--- a/WeakAuras/BaseRegions/TextureCoords.lua
+++ b/WeakAuras/BaseRegions/TextureCoords.lua
@@ -122,15 +122,6 @@ local funcs = {
     self.URy = 0
     self.LRx = 1
     self.LRy = 1
-
-    self.ULvx = 0
-    self.ULvy = 0
-    self.LLvx = 0
-    self.LLvy = 0
-    self.URvx = 0
-    self.URvy = 0
-    self.LRvx = 0
-    self.LRvy = 0
   end,
 
   Apply = function(self)

--- a/WeakAuras/BaseRegions/TextureCoords.lua
+++ b/WeakAuras/BaseRegions/TextureCoords.lua
@@ -1,0 +1,209 @@
+if not WeakAuras.IsLibsOK() then return end
+
+local AddonName = ...
+local Private = select(2, ...)
+
+local L = WeakAuras.L
+
+
+Private.TextureCoords = {}
+
+local defaultTexCoord = {
+  ULx = 0,
+  ULy = 0,
+  LLx = 0,
+  LLy = 1,
+  URx = 1,
+  URy = 0,
+  LRx = 1,
+  LRy = 1,
+}
+
+local exactAngles = {
+  {0.5, 0},  -- 0°
+  {1, 0},    -- 45°
+  {1, 0.5},  -- 90°
+  {1, 1},    -- 135°
+  {0.5, 1},  -- 180°
+  {0, 1},    -- 225°
+  {0, 0.5},  -- 270°
+  {0, 0}     -- 315°
+}
+
+local function angleToCoord(angle)
+  angle = angle % 360
+
+  if (angle % 45 == 0) then
+    local index = floor (angle / 45) + 1
+    return exactAngles[index][1], exactAngles[index][2]
+  end
+
+  if (angle < 45) then
+    return 0.5 + tan(angle) / 2, 0
+  elseif (angle < 135) then
+    return 1, 0.5 + tan(angle - 90) / 2
+  elseif (angle < 225) then
+    return 0.5 - tan(angle) / 2, 1
+  elseif (angle < 315) then
+    return 0, 0.5 - tan(angle - 90) / 2
+  elseif (angle < 360) then
+    return 0.5 + tan(angle) / 2, 0
+  end
+end
+
+
+local pointOrder = { "LL", "UL", "UR", "LR", "LL", "UL", "UR", "LR", "LL", "UL", "UR", "LR" }
+
+local function TransformPoint(x, y, scalex, scaley, texRotation, mirror_h, mirror_v, user_x, user_y)
+  -- 1) Translate texture-coords to user-defined center
+  x = x - 0.5
+  y = y - 0.5
+
+  -- 2) Shrink texture by 1/sqrt(2)
+  x = x * 1.4142
+  y = y * 1.4142
+
+  -- Not yet supported for circular progress
+  -- 3) Scale texture by user-defined amount
+  x = x / scalex
+  y = y / scaley
+
+  -- 4) Apply mirroring if defined
+  if mirror_h then
+    x = -x
+  end
+  if mirror_v then
+    y = -y
+  end
+
+  local cos_rotation = cos(texRotation)
+  local sin_rotation = sin(texRotation)
+
+  -- 5) Rotate texture by user-defined value
+  x, y = cos_rotation * x - sin_rotation * y, sin_rotation * x + cos_rotation * y
+
+  -- 6) Translate texture-coords back to (0,0)
+  x = x + 0.5
+  y = y + 0.5
+
+  x = x + (user_x or 0)
+  y = y + (user_y or 0)
+
+  return x, y
+end
+
+
+local funcs = {
+  MoveCorner = function (self, width, height, corner, x, y)
+    local rx = defaultTexCoord[corner .. "x"] - x
+    local ry = defaultTexCoord[corner .. "y"] - y
+    self[corner .. "vx"] = -rx * width
+    self[corner .. "vy"] = ry * height
+
+    self[corner .. "x"] = x
+    self[corner .. "y"] = y
+  end,
+
+  Hide = function(self)
+    self.texture:Hide()
+  end,
+
+  Show = function(self)
+    self:Apply()
+    self.texture:Show()
+  end,
+
+  SetFull = function(self)
+    self.ULx = 0
+    self.ULy = 0
+    self.LLx = 0
+    self.LLy = 1
+    self.URx = 1
+    self.URy = 0
+    self.LRx = 1
+    self.LRy = 1
+
+    self.ULvx = 0
+    self.ULvy = 0
+    self.LLvx = 0
+    self.LLvy = 0
+    self.URvx = 0
+    self.URvy = 0
+    self.LRvx = 0
+    self.LRvy = 0
+  end,
+
+  Apply = function(self)
+    self.texture:SetVertexOffset(UPPER_RIGHT_VERTEX, self.URvx, self.URvy)
+    self.texture:SetVertexOffset(UPPER_LEFT_VERTEX, self.ULvx, self.ULvy)
+    self.texture:SetVertexOffset(LOWER_RIGHT_VERTEX, self.LRvx, self.LRvy)
+    self.texture:SetVertexOffset(LOWER_LEFT_VERTEX, self.LLvx, self.LLvy)
+
+    self.texture:SetTexCoord(self.ULx, self.ULy, self.LLx, self.LLy, self.URx, self.URy, self.LRx, self.LRy)
+  end,
+  SetAngle = function(self, width, height, angle1, angle2)
+    local index = floor((angle1 + 45) / 90)
+
+    local middleCorner = pointOrder[index + 1]
+    local startCorner = pointOrder[index + 2]
+    local endCorner1 = pointOrder[index + 3]
+    local endCorner2 = pointOrder[index + 4]
+
+    -- LL => 32, 32
+    -- UL => 32, -32
+    self:MoveCorner(width, height, middleCorner, 0.5, 0.5)
+    self:MoveCorner(width, height, startCorner, angleToCoord(angle1))
+
+    local edge1 = floor((angle1 - 45) / 90)
+    local edge2 = floor((angle2 -45) / 90)
+
+    if (edge1 == edge2) then
+      self:MoveCorner(width, height, endCorner1, angleToCoord(angle2))
+    else
+      self:MoveCorner(width, height, endCorner1, defaultTexCoord[endCorner1 .. "x"], defaultTexCoord[endCorner1 .. "y"])
+    end
+
+    self:MoveCorner(width, height, endCorner2, angleToCoord(angle2))
+  end,
+
+  Transform = function(self, scalex, scaley, texRotation, mirror_h, mirror_v, user_x, user_y)
+      self.ULx, self.ULy = TransformPoint(self.ULx, self.ULy, scalex, scaley,
+                                          texRotation, mirror_h, mirror_v, user_x, user_y)
+      self.LLx, self.LLy = TransformPoint(self.LLx, self.LLy, scalex, scaley,
+                                          texRotation, mirror_h, mirror_v, user_x, user_y)
+      self.URx, self.URy = TransformPoint(self.URx, self.URy, scalex, scaley,
+                                          texRotation, mirror_h, mirror_v, user_x, user_y)
+      self.LRx, self.LRy = TransformPoint(self.LRx, self.LRy, scalex, scaley,
+                                          texRotation, mirror_h, mirror_v, user_x, user_y)
+  end
+}
+
+function Private.TextureCoords.create(texture)
+  local coord = {
+    ULx = 0,
+    ULy = 0,
+    LLx = 0,
+    LLy = 1,
+    URx = 1,
+    URy = 0,
+    LRx = 1,
+    LRy = 1,
+
+    ULvx = 0,
+    ULvy = 0,
+    LLvx = 0,
+    LLvy = 0,
+    URvx = 0,
+    URvy = 0,
+    LRvx = 0,
+    LRvy = 0,
+
+    texture = texture
+  }
+
+  for k, f in pairs(funcs) do
+    coord[k] = f
+  end
+
+  return coord
+end

--- a/WeakAuras/RegionTypes/ProgressTexture.lua
+++ b/WeakAuras/RegionTypes/ProgressTexture.lua
@@ -728,7 +728,7 @@ local function create(parent)
   region.regionType = "progresstexture"
   region:SetMovable(true);
   region:SetResizable(true);
-  region:SetResizeBounds(1, 1)
+  region:SetMinResize(1, 1);
 
   local background = Private.LinearProgressTextureBase.create(region, "BACKGROUND", 0);
   region.background = background;
@@ -746,7 +746,7 @@ local function create(parent)
   -- Use a dummy object for the SmoothStatusBarMixin, because our SetValue
   -- is used for a different purpose
   region.smoothProgress = {};
-  Mixin(region.smoothProgress, Private.SmoothStatusBarMixin);
+  WeakAuras.Mixin(region.smoothProgress, Private.SmoothStatusBarMixin);
   region.smoothProgress.SetValue = function(self, progress)
     region:SetValueOnTexture(progress);
     region:ReapplyAdditionalProgress()

--- a/WeakAuras/RegionTypes/ProgressTexture.lua
+++ b/WeakAuras/RegionTypes/ProgressTexture.lua
@@ -730,15 +730,15 @@ local function create(parent)
   region:SetResizable(true);
   region:SetMinResize(1, 1);
 
-  local background = Private.LinearProgressTextureBase.create(region, "BACKGROUND", 0);
+  local background = Private.LinearProgressTextureBase.create(region, "BACKGROUND");
   region.background = background;
 
   -- For horizontal/vertical progress
-  local foreground = Private.LinearProgressTextureBase.create(region, "ARTWORK", 0);
+  local foreground = Private.LinearProgressTextureBase.create(region, "ARTWORK");
   region.foreground = foreground;
 
-  region.foregroundSpinner = Private.CircularProgressTextureBase.create(region, "ARTWORK", 1)
-  region.backgroundSpinner = Private.CircularProgressTextureBase.create(region, "BACKGROUND", 1)
+  region.foregroundSpinner = Private.CircularProgressTextureBase.create(region, "ARTWORK", parent:GetFrameLevel() + 2)
+  region.backgroundSpinner = Private.CircularProgressTextureBase.create(region, "BACKGROUND", parent:GetFrameLevel() + 1)
 
   region.extraTextures = {};
   region.extraSpinners = {};

--- a/WeakAuras/RegionTypes/ProgressTexture.lua
+++ b/WeakAuras/RegionTypes/ProgressTexture.lua
@@ -7,7 +7,7 @@ local L = WeakAuras.L;
 local defaultFont = WeakAuras.defaultFont
 local defaultFontSize = WeakAuras.defaultFontSize
 
--- Credit to CommanderSirow for taking the time to properly craft the ApplyTransform function
+-- Credit to CommanderSirow for taking the time to properly craft the TransformPoint function
 -- to the enhance the abilities of Progress Textures.
 -- Also Credit to Semlar for explaining how circular progress can be shown
 
@@ -19,66 +19,8 @@ local defaultFontSize = WeakAuras.defaultFontSize
 --   region.user_y (0) - User defined center y-shift [-1, 1]
 --   region.mirror_v (false) - Mirroring along x-axis [bool]
 --   region.mirror_h (false) - Mirroring along y-axis [bool]
---   region.cos_rotation (1) - cos(ANGLE), precalculated cos-function for given ANGLE [-1, 1]
---   region.sin_rotation (0) - sin(ANGLE), precalculated cos-function for given ANGLE [-1, 1]
 --   region.scale (1.0) - user defined scaling [1, INF]
 --   region.full_rotation (false) - Allow full rotation [bool]
-
-
-local function ApplyTransform(x, y, region)
-  -- 1) Translate texture-coords to user-defined center
-  x = x - 0.5
-  y = y - 0.5
-
-  -- 2) Shrink texture by 1/sqrt(2)
-  x = x * 1.4142
-  y = y * 1.4142
-
-  if (region.orientation ~= "CLOCKWISE" and region.orientation ~= "ANTICLOCKWISE") then
-    -- Not yet supported for circular progress
-    -- 3) Scale texture by user-defined amount
-    x = x / region.scale_x
-    y = y / region.scale_y
-
-    -- 4) Apply mirroring if defined
-    if region.mirror_h then
-      x = -x
-    end
-    if region.mirror_v then
-      y = -y
-    end
-  else
-    x = x / region.scale
-    y = y / region.scale
-  end
-
-  -- 5) Rotate texture by user-defined value
-  x, y = region.cos_rotation * x - region.sin_rotation * y, region.sin_rotation * x + region.cos_rotation * y
-
-  -- 6) Translate texture-coords back to (0,0)
-  x = x + 0.5
-  y = y + 0.5
-
-  if (region.orientation ~= "CLOCKWISE" and region.orientation ~= "ANTICLOCKWISE") then
-    x = x + region.user_x
-    y = y + region.user_y
-  end
-
-  return x, y
-end
-
-local function Transform(tx, x, y, angle, aspect) -- Translates texture to x, y and rotates around its center
-  local c, s = cos(angle), sin(angle)
-  y = y / aspect
-  local oy =  0.5 / aspect
-
-
-  local ULx, ULy = 0.5 + (x - 0.5) * c - (y - oy) * s, (oy + (y - oy) * c + (x - 0.5) * s) * aspect
-  local LLx, LLy = 0.5 + (x - 0.5) * c - (y + oy) * s, (oy + (y + oy) * c + (x - 0.5) * s) * aspect
-  local URx, URy = 0.5 + (x + 0.5) * c - (y - oy) * s, (oy + (y - oy) * c + (x + 0.5) * s) * aspect
-  local LRx, LRy = 0.5 + (x + 0.5) * c - (y + oy) * s, (oy + (y + oy) * c + (x + 0.5) * s) * aspect
-  tx:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy)
-end
 
 local default = {
   progressSource = {-1, "" },
@@ -104,7 +46,8 @@ local default = {
   user_y = 0,
   crop_x = 0.41,
   crop_y = 0.41,
-  rotation = 0,
+  rotation = 0, -- Uses tex coord rotation, called "legacy rotation" in the ui and texRotation in code everywhere else
+  auraRotation = 0, -- Uses texture:SetRotation
   selfPoint = "CENTER",
   anchorPoint = "CENTER",
   anchorFrameType = "SCREEN",
@@ -168,6 +111,15 @@ local properties = {
     type = "list",
     values = Private.orientation_with_circle_types
   },
+  auraRotation = {
+    display = L["Rotation"],
+    setter = "SetAuraRotation",
+    type = "number",
+    min = 0,
+    max = 360,
+    bigStep = 10,
+    default = 0
+  },
   inverse = {
     display = L["Inverse"],
     setter = "SetInverse",
@@ -176,8 +128,35 @@ local properties = {
   mirror = {
     display = L["Mirror"],
     setter = "SetMirror",
-    type = "bool"
-  }
+    type = "bool",
+  },
+  rotation = {
+    display = L["Texture Rotation"],
+    setter = "SetTexRotation",
+    type = "number",
+    min = 0,
+    max = 360,
+    bigStep = 1,
+    default = 0
+  },
+  crop_x = {
+    display = L["Crop X"],
+    setter = "SetCropX",
+    type = "number",
+    min = 0,
+    softMax = 2,
+    bigStep = 0.01,
+    isPercent = true,
+  },
+  crop_y = {
+    display = L["Crop Y"],
+    setter = "SetCropY",
+    type = "number",
+    min = 0,
+    softMax = 2,
+    bigStep = 0.01,
+    isPercent = true,
+  },
 }
 
 Private.regionPrototype.AddProperties(properties, default);
@@ -201,273 +180,235 @@ local function GetProperties(data)
   end
 end
 
-local spinnerFunctions = {};
 
-function spinnerFunctions.SetTexture(self, texture)
-  for i = 1, 4 do
-    self.textures[i]:SetTexture(texture);
-  end
-  self.wedge:SetTexture(texture);
+local TextureSetValueFunction = function(self, progress)
+  self.progress = progress;
+  progress = max(0, progress);
+  progress = min(1, progress);
+  self.foreground:SetValue(0, progress);
 end
 
-function spinnerFunctions.SetDesaturated(self, desaturate)
-  for i = 1, 4 do
-    self.textures[i]:SetDesaturated(desaturate);
-  end
-  self.wedge:SetDesaturated(desaturate);
-end
+local CircularSetValueFunctions = {
+  ["CLOCKWISE"] = function(self, progress)
+    local startAngle = self.startAngle;
+    local endAngle = self.endAngle;
+    progress = progress or 0;
+    self.progress = progress;
 
-function spinnerFunctions.SetBlendMode(self, blendMode)
-  for i = 1, 4 do
-    self.textures[i]:SetBlendMode(blendMode);
-  end
-  self.wedge:SetBlendMode(blendMode);
-end
-
-function spinnerFunctions.Show(self)
-  for i = 1, 4 do
-    self.textures[i]:Show();
-  end
-  self.wedge:Show();
-end
-
-function spinnerFunctions.Hide(self)
-  for i = 1, 4 do
-    self.textures[i]:Hide();
-  end
-  self.wedge:Hide();
-end
-
-function spinnerFunctions.Color(self, r, g, b, a)
-  for i = 1, 4 do
-    self.textures[i]:SetVertexColor(r, g, b, a);
-  end
-  self.wedge:SetVertexColor(r, g, b, a);
-end
-
-function spinnerFunctions.SetBackgroundOffset(self, region, offset)
-  self.offset = offset;
-  self.textures[1]:SetPoint("TOPRIGHT", region, offset, offset)
-  self.textures[2]:SetPoint("BOTTOMRIGHT", region, offset, -offset)
-  self.textures[3]:SetPoint("BOTTOMLEFT", region, -offset, -offset)
-  self.textures[4]:SetPoint("TOPLEFT", region, -offset, offset)
-end
-
-function spinnerFunctions:SetHeight(height)
-  self.wedge:SetHeight(height);
-end
-
-function spinnerFunctions:SetWidth(width)
-  self.wedge:SetWidth(width);
-end
-
-local function betweenAngles(low, high, needle1, needle2)
-  if (low <= needle1 and needle1 <= high
-    and low <= needle2 and needle2 <= high) then
-    return true;
-  end
-
-  needle1 = needle1 + 360;
-  needle2 = needle2 + 360;
-  if (low <= needle1 and needle1 <= high
-    and low <= needle2 and needle2 <= high) then
-    return true;
-  end
-  return false;
-end
-
-local function animRotate(object, degrees, anchor, regionRotate, aspect)
-  if (not anchor) then
-    anchor = "CENTER";
-  end
-
-  object.degrees = degrees;
-  object.regionRotate = regionRotate;
-  object.aspect = aspect;
-
-  -- Something to rotate
-  -- Create AnimationGroup and rotation animation
-  if (not object.animationGroup) then
-    object.animationGroup = object:CreateAnimationGroup();
-    object.animationGroup:SetLooping("REPEAT")
-  end
-
-  object.animationGroup.rotate = object.animationGroup.rotate or object.animationGroup:CreateAnimation("rotation");
-
-  local rotate = object.animationGroup.rotate;
-  rotate:SetOrigin(anchor, 0, 0);
-  rotate:SetDegrees(degrees);
-  rotate:SetDuration( 0 );
-  rotate:SetEndDelay(15); -- 2147483647
-  Transform(object, -0.5, -0.5, -degrees + regionRotate, aspect)
-  object.animationGroup:Play();
-end
-
-function spinnerFunctions.SetProgress(self, region, startAngle, endAngle, progress, clockwise)
-  local pAngle = (endAngle - startAngle) * progress + startAngle;
-
-  -- Show/hide necessary textures if we need to
-  for i = 1, 4 do
-    local quadrantAngle1;
-    local quadrantAngle2;
-
-    if (clockwise) then
-      quadrantAngle2 = i * 90;
-      quadrantAngle1 = quadrantAngle2 - 90;
-    else
-      quadrantAngle2 = (5 - i) * 90;
-      quadrantAngle1 = quadrantAngle2 - 90;
+    if (progress < 0) then
+      progress = 0;
     end
 
-    if clockwise then
-      if betweenAngles(startAngle, pAngle, quadrantAngle1, quadrantAngle2) then
-        self.textures[i]:Show()
-      else
-        self.textures[i]:Hide()
+    if (progress > 1) then
+      progress = 1;
+    end
+
+    local pAngle = (endAngle - startAngle) * progress + startAngle;
+    self.foregroundSpinner:SetProgress(startAngle, pAngle);
+  end,
+  ["ANTICLOCKWISE"] = function(self, progress)
+    local startAngle = self.startAngle;
+    local endAngle = self.endAngle;
+    progress = progress or 0;
+    self.progress = progress;
+
+    if (progress < 0) then
+      progress = 0;
+    end
+
+    if (progress > 1) then
+      progress = 1;
+    end
+    progress = 1 - progress;
+
+    local pAngle = (endAngle - startAngle) * progress + startAngle;
+    self.foregroundSpinner:SetProgress(pAngle, endAngle);
+  end
+}
+
+local function hideExtraTextures(extraTextures, from)
+  for i = from, #extraTextures do
+    extraTextures[i]:Hide();
+  end
+end
+
+local function ensureExtraTextures(region, count)
+  local auraRotationRadians = region.auraRotation / 180 * math.pi
+  for i = #region.extraTextures + 1, count do
+    local extraTexture = Private.LinearProgressTextureBase.create(region, "ARTWORK", min(i, 7));
+    Private.LinearProgressTextureBase.modify(extraTexture, {
+      offset = 0,
+      blendMode = region.foreground:GetBlendMode(),
+      desaturated = false,
+      auraRotation = auraRotationRadians,
+      texture = region.currentTexture,
+      crop_x = region.crop_x,
+      crop_y = region.crop_y,
+      user_x = region.user_x,
+      user_y = region.user_y,
+      mirror = region.mirror,
+      texRotation = region.effectiveTexRotation,
+      width = region.width,
+      height = region.height
+    })
+    extraTexture:SetOrientation(region.orientation, region.compress, region.slanted, region.slant,
+                                region.slantFirst, region.slantMode)
+    region.extraTextures[i] = extraTexture;
+  end
+end
+
+local function ensureExtraSpinners(region, count)
+  local auraRotationRadians = region.auraRotation / 180 * math.pi
+  for i = #region.extraSpinners + 1, count do
+    local extraSpinner = Private.CircularProgressTextureBase.create(region, "OVERLAY", min(i, 7))
+    Private.CircularProgressTextureBase.modify(extraSpinner, {
+      crop_x = region.crop_x,
+      crop_y = region.crop_y,
+      mirror = region.mirror,
+      texRotation = region.effectiveTexRotation,
+      texture = region.currentTexture,
+      blendMode = region.foreground:GetBlendMode(),
+      desaturated = false,
+      auraRotation = auraRotationRadians,
+      width = region.width,
+      height = region.height,
+      offset = 0
+    })
+
+    extraSpinner:SetScale(region.scalex, region.scaley)
+
+    region.extraSpinners[i] = extraSpinner
+  end
+end
+
+local function convertToProgress(rprogress, additionalProgress, adjustMin, totalWidth, inverse, clamp)
+  local startProgress = 0;
+  local endProgress = 0;
+
+  if (additionalProgress.min and additionalProgress.max) then
+    if (totalWidth ~= 0) then
+      startProgress = (additionalProgress.min - adjustMin) / totalWidth;
+      endProgress = (additionalProgress.max - adjustMin) / totalWidth;
+
+      if (inverse) then
+        startProgress = 1 - startProgress;
+        endProgress = 1 - endProgress;
       end
-    else
-      if betweenAngles(startAngle, pAngle, quadrantAngle1, quadrantAngle2) then
-        self.textures[i]:Show()
+    end
+  elseif (additionalProgress.direction) then
+    local forwardDirection = (additionalProgress.direction or "forward") == "forward";
+    if (inverse) then
+      forwardDirection = not forwardDirection;
+    end
+    local width = additionalProgress.width or 0;
+    local offset = additionalProgress.offset or 0;
+    if (width ~= 0) then
+      if (forwardDirection) then
+        startProgress = rprogress + offset / totalWidth ;
+        endProgress = rprogress + (offset + width) / totalWidth;
       else
-        self.textures[i]:Hide()
+        startProgress = rprogress - (width + offset) / totalWidth;
+        endProgress = rprogress - offset / totalWidth;
       end
     end
   end
 
-  -- Move scrollframe/wedge to the proper quadrant
-  local quadrant = floor(pAngle % 360 / 90) + 1;
-  if (not clockwise) then
-    quadrant = 5 - quadrant;
+  if (clamp) then
+    startProgress = max(0, min(1, startProgress));
+    endProgress = max(0, min(1, endProgress));
   end
-  self.scrollframe:Hide();
-  self.scrollframe:SetAllPoints(self.textures[quadrant])
-  self.scrollframe:Show();
 
-  local ULx, ULy = ApplyTransform(0, 0, region)
-  local LLx, LLy = ApplyTransform(0, 1, region)
-  local URx, URy = ApplyTransform(1, 0, region)
-  local LRx, LRy = ApplyTransform(1, 1, region)
-
-  local Lx, Ly = ApplyTransform(0, 0.5, region)
-  local Tx, Ty = ApplyTransform(0.5, 0, region)
-  local Bx, By = ApplyTransform(0.5, 1, region)
-  local Rx, Ry = ApplyTransform(1, 0.5, region)
-  local Cx, Cy = ApplyTransform(0.5, 0.5, region)
-
-  self.textures[1]:SetTexCoord(Tx, Ty, Cx, Cy, URx, URy, Rx, Ry);
-  self.textures[2]:SetTexCoord(Cx, Cy, Bx, By, Rx, Ry, LRx, LRy);
-  self.textures[3]:SetTexCoord(Lx, Ly, LLx, LLy, Cx, Cy, Bx, By);
-  self.textures[4]:SetTexCoord(ULx, ULy, Lx, Ly, Tx, Ty, Cx, Cy);
-
-  local degree = pAngle;
-  if not clockwise then degree = -degree + 90 end
-
-  animRotate(self.wedge, -degree, "BOTTOMRIGHT", region.rotation, region.aspect);
+  return startProgress, endProgress;
 end
 
-local function createSpinner(parent, layer, frameLevel)
-  -- For circular progress
-  local scrollframe = CreateFrame("ScrollFrame", nil, parent)
-  scrollframe:SetPoint("BOTTOMLEFT", parent, "CENTER")
-  scrollframe:SetPoint("TOPRIGHT")
-  scrollframe:SetFrameLevel(frameLevel);
+local function ApplyAdditionalProgressLinear(self, additionalProgress, min, max, inverse)
+  self.additionalProgress = additionalProgress;
+  self.additionalProgressMin = min;
+  self.additionalProgressMax = max;
+  self.additionalProgressInverse = inverse;
 
-  local scrollchild = CreateFrame("Frame", nil, scrollframe)
-  scrollframe:SetScrollChild(scrollchild)
-  scrollchild:SetAllPoints(scrollframe)
-  scrollchild:SetFrameLevel(frameLevel);
+  local effectiveInverse = (inverse and not self.inverseDirection) or (not inverse and self.inverseDirection);
 
-  -- Wedge thing
-  local wedge = scrollchild:CreateTexture(nil, layer)
-  wedge:SetPoint("BOTTOMRIGHT", parent, "CENTER")
+  if (additionalProgress) then
+    ensureExtraTextures(self, #additionalProgress);
+    local totalWidth = max - min;
+    for index, additionalProgress in ipairs(additionalProgress) do
+      local extraTexture = self.extraTextures[index];
 
-  -- Top Right
-  local trTexture = parent:CreateTexture(nil, layer)
-  trTexture:SetPoint("BOTTOMLEFT", parent, "CENTER")
-  trTexture:SetPoint("TOPRIGHT")
-  trTexture:SetTexCoord(0.5, 1, 0, 0.5)
+      local startProgress, endProgress = convertToProgress(self.progress, additionalProgress, min,
+                                                           totalWidth, effectiveInverse, self.overlayclip)
+      if ((endProgress - startProgress) == 0) then
+        extraTexture:Hide();
+      else
+        extraTexture:Show();
+        local color = self.overlays[index];
+        if (color) then
+          extraTexture:SetColor(unpack(color));
+        else
+          extraTexture:SetColor(1, 1, 1, 1);
+        end
 
-  -- Bottom Right
-  local brTexture = parent:CreateTexture(nil, layer)
-  brTexture:SetPoint("TOPLEFT", parent, "CENTER")
-  brTexture:SetPoint("BOTTOMRIGHT")
-  brTexture:SetTexCoord(0.5, 1, 0.5, 1)
+        extraTexture:SetValue(startProgress, endProgress)
+      end
+    end
 
-  -- Bottom Left
-  local blTexture = parent:CreateTexture(nil, layer)
-  blTexture:SetPoint("TOPRIGHT", parent, "CENTER")
-  blTexture:SetPoint("BOTTOMLEFT")
-  blTexture:SetTexCoord(0, 0.5, 0.5, 1)
-
-  -- Top Left
-  local tlTexture = parent:CreateTexture(nil, layer)
-  tlTexture:SetPoint("BOTTOMRIGHT", parent, "CENTER")
-  tlTexture:SetPoint("TOPLEFT")
-  tlTexture:SetTexCoord(0, 0.5, 0, 0.5)
-
-  -- /4|1\ -- Clockwise texture arrangement
-  -- \3|2/ --
-
-  local spinner = {};
-
-  spinner.scrollframe = scrollframe
-  spinner.wedge = wedge
-  spinner.textures = {trTexture, brTexture, blTexture, tlTexture}
-
-  for k, v in pairs(spinnerFunctions) do
-    spinner[k] = v;
+    hideExtraTextures(self.extraTextures, #additionalProgress + 1);
+  else
+    hideExtraTextures(self.extraTextures, 1);
   end
-
-  return spinner;
 end
 
--- Make available for the thumbnail display
-WeakAuras.createSpinner = createSpinner;
+local function ApplyAdditionalProgressCircular(self, additionalProgress, min, max, inverse)
+  self.additionalProgress = additionalProgress;
+  self.additionalProgressMin = min;
+  self.additionalProgressMax = max;
+  self.additionalProgressInverse = inverse;
 
-local function create(parent)
-  local font = "GameFontHighlight";
+  local effectiveInverse = (inverse and not self.inverseDirection) or (not inverse and self.inverseDirection);
 
-  local region = CreateFrame("Frame", nil, parent);
-  region.regionType = "progresstexture"
-  region:SetMovable(true);
-  region:SetResizable(true);
-  region:SetMinResize(1, 1);
+  if (additionalProgress) then
+    ensureExtraSpinners(self, #additionalProgress);
+    local totalWidth = max - min;
+    for index, additionalProgress in ipairs(additionalProgress) do
+      local extraSpinner = self.extraSpinners[index];
 
-  local background = region:CreateTexture(nil, "BACKGROUND");
-  region.background = background;
+      local startProgress, endProgress = convertToProgress(self.progress, additionalProgress, min,
+                                                           totalWidth, effectiveInverse, self.overlayclip)
+      if (endProgress < startProgress) then
+        startProgress, endProgress = endProgress, startProgress;
+      end
 
-  -- For horizontal/vertical progress
-  local foreground = region:CreateTexture(nil, "ARTWORK");
-  region.foreground = foreground;
+      if (self.orientation == "ANTICLOCKWISE") then
+        startProgress, endProgress = 1 - endProgress, 1 - startProgress;
+      end
 
-  region.foregroundSpinner = createSpinner(region, "ARTWORK", parent:GetFrameLevel() + 2);
-  region.backgroundSpinner = createSpinner(region, "BACKGROUND", parent:GetFrameLevel() + 1);
+      if ((endProgress - startProgress) == 0) then
+        extraSpinner:SetProgress(0, 0)
+      else
+        local color = self.overlays[index];
+        if (color) then
+          extraSpinner:SetColor(unpack(color));
+        else
+          extraSpinner:SetColor(1, 1, 1, 1);
+        end
 
-  region.extraTextures = {};
-  region.extraSpinners = {};
+        local startAngle = self.startAngle;
+        local diffAngle = self.endAngle - startAngle;
+        local pAngleStart = diffAngle * startProgress + startAngle;
+        local pAngleEnd = diffAngle * endProgress + startAngle;
 
-  -- Use a dummy object for the SmoothStatusBarMixin, because our SetValue
-  -- is used for a different purpose
-  region.smoothProgress = {};
-  WeakAuras.Mixin(region.smoothProgress, Private.SmoothStatusBarMixin);
-  region.smoothProgress.SetValue = function(self, progress)
-    region:SetValueOnTexture(progress);
+        if (pAngleStart < 0) then
+          pAngleStart = pAngleStart + 360;
+          pAngleEnd = pAngleEnd + 360;
+        end
+
+        extraSpinner:SetProgress(pAngleStart, pAngleEnd)
+      end
+    end
+
+  else
+    hideExtraTextures(self.extraSpinners, 1);
   end
-
-  region.smoothProgress.GetValue = function(self)
-    return region.progress;
-  end
-
-  region.smoothProgress.GetMinMaxValues = function(self)
-    return 0, 1;
-  end
-
-  region.duration = 0;
-  region.expirationTime = math.huge;
-
-  Private.regionPrototype.create(region);
-
-  return region;
 end
 
 local function FrameTick(self)
@@ -491,14 +432,354 @@ local function FrameTick(self)
     self.smoothProgress:SetSmoothedValue(progress);
   else
     self:SetValueOnTexture(progress);
+    self:ReapplyAdditionalProgress()
   end
 end
+
+local funcs = {
+  ForAllSpinners = function(self, f, ...)
+    f(self.foregroundSpinner, ...)
+    f(self.backgroundSpinner, ...)
+    for i, extraSpinner in ipairs(self.extraSpinners) do
+      f(extraSpinner, ...)
+    end
+  end,
+  ForAllLinears = function(self, f, ...)
+    f(self.foreground, ...)
+    f(self.background, ...)
+    for _, extraTexture in ipairs(self.extraTextures) do
+      f(extraTexture, ...)
+    end
+  end,
+  SetOrientation = function (self, orientation)
+    self.orientation = orientation
+    if(self.orientation == "CLOCKWISE" or self.orientation == "ANTICLOCKWISE") then
+      self.circular = true
+      self.foreground:Hide()
+      self.background:Hide()
+      self.foregroundSpinner:Show()
+      self.backgroundSpinner:Show()
+
+      for i = 1, #self.extraTextures do
+        self.extraTextures[i]:Hide()
+      end
+      self.foregroundSpinner:UpdateTextures()
+      self.backgroundSpinner:UpdateTextures()
+      self.SetValueOnTexture = CircularSetValueFunctions[self.orientation]
+      self.ApplyAdditionalProgress = ApplyAdditionalProgressCircular
+    else
+      self.circular = false
+      self.foreground:Show()
+      self.background:Show()
+      self.foregroundSpinner:Hide()
+      self.backgroundSpinner:Hide()
+
+      for i = 1, #self.extraSpinners do
+        self.extraSpinners[i]:Hide()
+      end
+      self.background:SetOrientation(orientation, nil, self.slanted, self.slant,
+                                       self.slantFirst, self.slantMode)
+      self.foreground:SetOrientation(orientation, self.compress, self.slanted, self.slant,
+                                       self.slantFirst, self.slantMode)
+      self.SetValueOnTexture = TextureSetValueFunction;
+      self.ApplyAdditionalProgress = ApplyAdditionalProgressLinear
+
+      for _, extraTexture in ipairs(self.extraTextures) do
+        extraTexture:SetOrientation(orientation, self.compress, self.slanted, self.slant,
+                                    self.slantFirst, self.slantMode)
+      end
+    end
+    self:SetValueOnTexture(self.progress)
+    self:ReapplyAdditionalProgress()
+  end,
+  SetAnimRotation = function(self, angle)
+    self.texAnimationRotation = angle
+    self:UpdateEffectiveRotation()
+  end,
+  SetTexRotation = function(self, angle)
+    self.texRotation = angle
+    self:UpdateEffectiveRotation()
+  end,
+  GetBaseRotation = function(self)
+    return self.texRotation
+  end,
+  Color = function(self, r, g, b, a)
+    self.color_r = r
+    self.color_g = g
+    self.color_b = b
+    if (r or g or b) then
+      a = a or 1
+    end
+    self.color_a = a
+    self.foreground:SetColor(self.color_anim_r or r, self.color_anim_g or g,
+                                   self.color_anim_b or b, self.color_anim_a or a)
+    self.foregroundSpinner:SetColor(self.color_anim_r or r, self.color_anim_g or g,
+                                    self.color_anim_b or b, self.color_anim_a or a)
+  end,
+  ColorAnim = function(self, r, g, b, a)
+    self.color_anim_r = r
+    self.color_anim_g = g
+    self.color_anim_b = b
+    self.color_anim_a = a
+    if (r or g or b) then
+      a = a or 1;
+    end
+    self.foreground:SetColor(r or self.color_r, g or self.color_g, b or self.color_b, a or self.color_a)
+    self.foregroundSpinner:SetColor(r or self.color_r, g or self.color_g, b or self.color_b, a or self.color_a)
+  end,
+  GetColor = function(self)
+    return self.color_r, self.color_g, self.color_b, self.color_a
+  end,
+  SetAuraRotation = function(self, auraRotation)
+    self.auraRotation = auraRotation
+    local auraRotationRadians = self.auraRotation / 180 * math.pi
+    self:ForAllSpinners(self.foregroundSpinner.SetAuraRotation, auraRotationRadians)
+
+    self.background:SetAuraRotation(auraRotationRadians)
+    self.foreground:SetAuraRotation(auraRotationRadians)
+    for _, extraTexture in ipairs(self.extraTextures) do
+      extraTexture:SetAuraRotation(auraRotationRadians)
+    end
+  end,
+  DoPosition = function(self)
+    self:SetWidth(self.width * self.scalex);
+    self:SetHeight(self.height * self.scaley);
+
+    if self.orientation == "CLOCKWISE" or self.orientation == "ANTICLOCKWISE" then
+      self:ForAllSpinners(self.foregroundSpinner.UpdateTextures)
+    else
+      self:ForAllLinears(self.foreground.Update)
+    end
+  end,
+  SetMirror = function(self, mirror)
+    self.mirror = mirror
+    self:ForAllSpinners(self.foregroundSpinner.SetMirror, mirror)
+    self:ForAllLinears(self.foreground.SetMirror, mirror)
+  end,
+  UpdateTextures = function(self)
+    if self.circular then
+      self:ForAllSpinners(self.foregroundSpinner.UpdateTextures)
+    else
+      self:ForAllLinears(self.foreground.UpdateTextures)
+    end
+  end,
+  SetCropX = function(self, x)
+    self.crop_x = 1 + x
+    self:ForAllSpinners(self.foregroundSpinner.SetCropX, self.crop_x)
+    self:ForAllLinears(self.foreground.SetCropX, self.crop_x)
+  end,
+  SetCropY = function(self, y)
+    self.crop_y = 1 + y
+    self:ForAllSpinners(self.foregroundSpinner.SetCropY, self.crop_y)
+    self:ForAllLinears(self.foreground.SetCropX, self.crop_x)
+  end,
+  UpdateEffectiveRotation = function(self)
+    self.effectiveTexRotation = self.texAnimationRotation or self.texRotation
+    self:ForAllSpinners(self.foregroundSpinner.SetTexRotation, self.effectiveTexRotation)
+    self:ForAllLinears(self.foreground.SetTexRotation, self.effectiveTexRotation)
+  end,
+  UpdateTime = function(self)
+    local progress = 1
+    if self.duration ~= 0 then
+      local remaining = self.expirationTime - GetTime()
+      progress = remaining / self.duration
+      local inversed = not self.inverse ~= not self.inverseDirection
+      if inversed then
+        progress = 1 - progress
+      end
+    end
+
+    progress = progress > 0.0001 and progress or 0.0001;
+    if (self.useSmoothProgress) then
+      self.smoothProgress:SetSmoothedValue(progress);
+    else
+      self:SetValueOnTexture(progress);
+      self:ReapplyAdditionalProgress()
+    end
+
+    if self.paused and self.FrameTick then
+      self.FrameTick = nil
+      self.subRegionEvents:RemoveSubscriber("FrameTick", self)
+    end
+    if not self.paused and not self.FrameTick then
+      self.FrameTick = FrameTick
+      self.subRegionEvents:AddSubscriber("FrameTick", self)
+    end
+  end,
+  UpdateValue = function(self)
+    local progress = 1
+    if(self.total > 0) then
+      progress = self.value / self.total;
+      if self.inverseDirection then
+        progress = 1 - progress;
+      end
+    end
+    progress = progress > 0.0001 and progress or 0.0001;
+    if self.useSmoothProgress then
+      self.smoothProgress:SetSmoothedValue(progress);
+    else
+      self:SetValueOnTexture(progress);
+      self:ReapplyAdditionalProgress()
+    end
+
+    if self.FrameTick then
+      self.FrameTick = nil
+      self.subRegionEvents:RemoveSubscriber("FrameTick", self)
+    end
+  end,
+  SetAdditionalProgress = function(self, additionalProgress, currentMin, currentMax, inverse)
+    self:ApplyAdditionalProgress(additionalProgress, currentMin, currentMax, inverse)
+  end,
+  ReapplyAdditionalProgress = function(self)
+    self:ApplyAdditionalProgress(self.additionalProgress, self.additionalProgressMin,
+                                 self.additionalProgressMax, self.additionalProgressInverse)
+  end,
+  Update = function(self)
+    self:UpdateProgress()
+    local state = self.state
+
+    if state.texture then
+      self:SetTexture(state.texture)
+    end
+  end,
+  SetTexture = function(self, texture)
+    self.currentTexture = texture
+    self.foreground:SetTextureOrAtlas(texture)
+    self.foregroundSpinner:SetTextureOrAtlas(texture);
+    if self.sameTexture then
+      self.background:SetTextureOrAtlas(texture)
+      self.backgroundSpinner:SetTextureOrAtlas(texture);
+    end
+
+    for _, extraTexture in ipairs(self.extraTextures) do
+      extraTexture:SetTextureOrAtlas(texture)
+    end
+
+    for _, extraSpinner in ipairs(self.extraSpinners) do
+      extraSpinner:SetTextureOrAtlas(texture);
+    end
+  end,
+  SetForegroundDesaturated = function(self, b)
+    self.foreground:SetDesaturated(b)
+    self.foregroundSpinner:SetDesaturated(b)
+  end,
+  SetBackgroundDesaturated = function(self, b)
+    self.background:SetDesaturated(b)
+    self.backgroundSpinner:SetDesaturated(b)
+  end,
+  SetBackgroundColor = function(self, r, g, b, a)
+    self.background:SetColor(r, g, b, a)
+    self.backgroundSpinner:SetColor(r, g, b, a)
+  end,
+  SetRegionWidth = function(self, width)
+    self.width = width;
+    self:ForAllSpinners(self.foregroundSpinner.SetWidth, width)
+    self:ForAllLinears(self.foreground.SetWidth, width)
+    self:Scale(self.scalex, self.scaley)
+  end,
+  SetRegionHeight = function(self, height)
+    self.height = height
+    self:ForAllSpinners(self.foregroundSpinner.SetHeight, height)
+    self:ForAllSpinners(self.foreground.SetHeight, height)
+    self:Scale(self.scalex, self.scaley)
+  end,
+  Scale = function(self, scalex, scaley)
+    if(scalex < 0) then
+      self.mirror_h = true
+      scalex = scalex * -1
+    end
+
+    if(scaley < 0) then
+      self.mirror_v = true
+      scaley = scaley * -1
+    end
+
+    self.scalex = scalex
+    self.scaley = scaley
+
+    self:ForAllSpinners(self.foregroundSpinner.SetScale, self.scalex, self.scaley)
+    self:ForAllSpinners(self.foregroundSpinner.SetMirrorHV, self.mirror_h, self.mirror_v)
+    self:ForAllLinears(self.foreground.SetMirrorHV, self.mirror_h, self.mirror_v)
+    self:DoPosition()
+  end,
+  SetInverse = function(self, inverse)
+    if self.inverseDirection == inverse then
+      return
+    end
+    self.inverseDirection = inverse
+    local progress = 1 - self.progress;
+    progress = progress > 0.0001 and progress or 0.0001;
+    self:SetValueOnTexture(progress)
+    self:ReapplyAdditionalProgress()
+  end,
+  SetOverlayColor = function(self, id, r, g, b, a)
+    self.overlays[id] = { r, g, b, a};
+    if self.extraTextures[id] then
+      self.extraTextures[id]:SetColor(r, g, b, a);
+    end
+    if self.extraSpinners[id] then
+      self.extraSpinners[id]:SetColor(r, g, b, a);
+    end
+  end
+}
+
+local function create(parent)
+  local region = CreateFrame("Frame", nil, parent);
+  region.regionType = "progresstexture"
+  region:SetMovable(true);
+  region:SetResizable(true);
+  region:SetResizeBounds(1, 1)
+
+  local background = Private.LinearProgressTextureBase.create(region, "BACKGROUND", 0);
+  region.background = background;
+
+  -- For horizontal/vertical progress
+  local foreground = Private.LinearProgressTextureBase.create(region, "ARTWORK", 0);
+  region.foreground = foreground;
+
+  region.foregroundSpinner = Private.CircularProgressTextureBase.create(region, "ARTWORK", 1)
+  region.backgroundSpinner = Private.CircularProgressTextureBase.create(region, "BACKGROUND", 1)
+
+  region.extraTextures = {};
+  region.extraSpinners = {};
+
+  -- Use a dummy object for the SmoothStatusBarMixin, because our SetValue
+  -- is used for a different purpose
+  region.smoothProgress = {};
+  Mixin(region.smoothProgress, Private.SmoothStatusBarMixin);
+  region.smoothProgress.SetValue = function(self, progress)
+    region:SetValueOnTexture(progress);
+    region:ReapplyAdditionalProgress()
+  end
+
+  region.smoothProgress.GetValue = function(self)
+    return region.progress;
+  end
+
+  region.smoothProgress.GetMinMaxValues = function(self)
+    return 0, 1;
+  end
+
+  for k, func in pairs(funcs) do
+    region[k] = func
+  end
+
+  Private.regionPrototype.create(region);
+
+  return region;
+end
+
 
 local function modify(parent, region, data)
   Private.regionPrototype.modify(parent, region, data);
 
   local background, foreground = region.background, region.foreground;
   local foregroundSpinner, backgroundSpinner = region.foregroundSpinner, region.backgroundSpinner;
+
+  background:Hide()
+  foreground:Hide()
+  foregroundSpinner:Hide()
+  backgroundSpinner:Hide()
 
   region:SetWidth(data.width);
   region:SetHeight(data.height);
@@ -507,413 +788,35 @@ local function modify(parent, region, data)
   region.scalex = 1;
   region.scaley = 1;
   region.aspect =  data.width / data.height;
+  region.overlayclip = data.overlayclip;
+
   region.useSmoothProgress = data.smoothProgress
-  foreground:SetWidth(data.width);
-  foreground:SetHeight(data.height);
-  local scaleWedge =  1 / 1.4142 * (1 + (data.crop or 0.41));
-  foregroundSpinner:SetWidth(data.width * scaleWedge);
-  foregroundSpinner:SetHeight(data.height * scaleWedge);
-  backgroundSpinner:SetWidth((data.width + data.backgroundOffset * 2) * scaleWedge);
-  backgroundSpinner:SetHeight((data.height + data.backgroundOffset * 2) * scaleWedge);
-
-  region:ClearAllPoints();
-  Private.AnchorFrame(data, region, parent)
-  region:SetAlpha(data.alpha);
-
-  background:SetTexture(data.sameTexture and data.foregroundTexture or data.backgroundTexture);
-  background:SetDesaturated(data.desaturateBackground)
-  background:SetVertexColor(data.backgroundColor[1], data.backgroundColor[2], data.backgroundColor[3], data.backgroundColor[4]);
-  background:SetBlendMode(data.blendMode);
-
-  backgroundSpinner:SetTexture(data.sameTexture and data.foregroundTexture or data.backgroundTexture);
-  backgroundSpinner:SetDesaturated(data.desaturateBackground)
-  backgroundSpinner:Color(data.backgroundColor[1], data.backgroundColor[2], data.backgroundColor[3], data.backgroundColor[4]);
-  backgroundSpinner:SetBlendMode(data.blendMode);
-
-  foreground:SetTexture(data.foregroundTexture);
-  foreground:SetDesaturated(data.desaturateForeground)
-  foreground:SetBlendMode(data.blendMode);
-
-  foregroundSpinner:SetTexture(data.foregroundTexture);
-  foregroundSpinner:SetDesaturated(data.desaturateForeground);
-  foregroundSpinner:SetBlendMode(data.blendMode);
-
-  background:ClearAllPoints();
-  foreground:ClearAllPoints();
-  background:SetPoint("BOTTOMLEFT", region, "BOTTOMLEFT", -1 * data.backgroundOffset, -1 * data.backgroundOffset);
-  background:SetPoint("TOPRIGHT", region, "TOPRIGHT", data.backgroundOffset, data.backgroundOffset);
-  backgroundSpinner:SetBackgroundOffset(region, data.backgroundOffset);
-
-  region.mirror_h = data.mirror;
-  region.scale_x = 1 + (data.crop_x or 0.41);
-  region.scale_y = 1 + (data.crop_y or 0.41);
-  region.scale = 1 + (data.crop or 0.41);
-  region.rotation = data.rotation or 0;
-  region.cos_rotation = cos(region.rotation);
-  region.sin_rotation = sin(region.rotation);
+  region.sameTexture = data.sameTexture
+  region.mirror = data.mirror
+  region.crop_x = 1 + data.crop_x
+  region.crop_y = 1 + data.crop_y
+  region.texRotation = data.rotation or 0
   region.user_x = -1 * (data.user_x or 0);
   region.user_y = data.user_y or 0;
-
-  region.startAngle = data.startAngle or 0;
-  region.endAngle = data.endAngle or 360;
-
-  local function orientHorizontal()
-    foreground:ClearAllPoints();
-    foreground:SetPoint("LEFT", region, "LEFT");
-    region.orientation = "HORIZONTAL_INVERSE";
-    if(data.compress) then
-      function region:SetValueOnTexture(progress)
-        region.progress = progress;
-
-        local ULx, ULy = ApplyTransform(0, 0, region)
-        local LLx, LLy = ApplyTransform(0, 1, region)
-        local URx, URy = ApplyTransform(1, 0, region)
-        local LRx, LRy = ApplyTransform(1, 1, region)
-
-        foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
-        foreground:SetWidth(region:GetWidth() * progress);
-        background:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
-      end
-    else
-      function region:SetValueOnTexture(progress)
-        region.progress = progress;
-
-        local ULx , ULy  = ApplyTransform(0, 0, region)
-        local LLx , LLy  = ApplyTransform(0, 1, region)
-        local URx , URy  = ApplyTransform(progress, 0, region)
-        local URx_, URy_ = ApplyTransform(1, 0, region)
-        local LRx , LRy  = ApplyTransform(progress, 1, region)
-        local LRx_, LRy_ = ApplyTransform(1, 1, region)
-
-        foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx , URy , LRx , LRy );
-        foreground:SetWidth(region:GetWidth() * progress);
-        background:SetTexCoord(ULx, ULy, LLx, LLy, URx_, URy_, LRx_, LRy_);
-      end
-    end
+  region.startAngle = (data.startAngle or 0) % 360;
+  region.endAngle = (data.endAngle or 360) % 360;
+  if (region.endAngle <= region.startAngle) then
+    region.endAngle = region.endAngle + 360;
   end
-  local function orientHorizontalInverse()
-    foreground:ClearAllPoints();
-    foreground:SetPoint("RIGHT", region, "RIGHT");
-    region.orientation = "HORIZONTAL";
-    if(data.compress) then
-      function region:SetValueOnTexture(progress)
-        region.progress = progress;
-
-        local ULx, ULy = ApplyTransform(0, 0, region)
-        local LLx, LLy = ApplyTransform(0, 1, region)
-        local URx, URy = ApplyTransform(1, 0, region)
-        local LRx, LRy = ApplyTransform(1, 1, region)
-
-        foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
-        foreground:SetWidth(region:GetWidth() * progress);
-        background:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
-      end
-    else
-      function region:SetValueOnTexture(progress)
-        region.progress = progress;
-
-        local ULx , ULy  = ApplyTransform(1-progress, 0, region)
-        local ULx_, ULy_ = ApplyTransform(0, 0, region)
-        local LLx , LLy  = ApplyTransform(1-progress, 1, region)
-        local LLx_, LLy_ = ApplyTransform(0, 1, region)
-        local URx , URy  = ApplyTransform(1, 0, region)
-        local LRx , LRy  = ApplyTransform(1, 1, region)
-
-        foreground:SetTexCoord(ULx , ULy , LLx , LLy , URx, URy, LRx, LRy);
-        foreground:SetWidth(region:GetWidth() * progress);
-        background:SetTexCoord(ULx_, ULy_, LLx_, LLy_, URx, URy, LRx, LRy);
-      end
-    end
+  region.compress = data.compress;
+  region.inverseDirection = data.inverse;
+  region.progress = 0.667;
+  if (data.overlays) then
+    region.overlays = CopyTable(data.overlays)
+  else
+    region.overlays = {}
   end
-  local function orientVertical()
-    foreground:ClearAllPoints();
-    foreground:SetPoint("BOTTOM", region, "BOTTOM");
-    region.orientation = "VERTICAL_INVERSE";
-    if(data.compress) then
-      function region:SetValueOnTexture(progress)
-        region.progress = progress;
-
-        local ULx, ULy = ApplyTransform(0, 0, region)
-        local LLx, LLy = ApplyTransform(0, 1, region)
-        local URx, URy = ApplyTransform(1, 0, region)
-        local LRx, LRy = ApplyTransform(1, 1, region)
-
-        foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
-        foreground:SetHeight(region:GetHeight() * progress);
-        background:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
-      end
-    else
-      function region:SetValueOnTexture(progress)
-        region.progress = progress;
-
-        local ULx , ULy  = ApplyTransform(0, 1 - progress, region)
-        local ULx_, ULy_ = ApplyTransform(0, 0, region)
-        local LLx , LLy  = ApplyTransform(0, 1, region)
-        local URx , URy  = ApplyTransform(1, 1 - progress, region)
-        local URx_, URy_ = ApplyTransform(1, 0, region)
-        local LRx , LRy  = ApplyTransform(1, 1, region)
-
-        foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
-        foreground:SetHeight(region:GetHeight() * progress);
-        background:SetTexCoord(ULx_, ULy_, LLx, LLy, URx_, URy_, LRx, LRy);
-      end
-    end
-  end
-  local function orientVerticalInverse()
-    foreground:ClearAllPoints();
-    foreground:SetPoint("TOP", region, "TOP");
-    region.orientation = "VERTICAL";
-    if(data.compress) then
-      function region:SetValueOnTexture(progress)
-        region.progress = progress;
-
-        local ULx, ULy = ApplyTransform(0, 0, region)
-        local LLx, LLy = ApplyTransform(0, 1, region)
-        local URx, URy = ApplyTransform(1, 0, region)
-        local LRx, LRy = ApplyTransform(1, 1, region)
-
-        foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
-        foreground:SetHeight(region:GetHeight() * progress);
-        background:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
-      end
-    else
-      function region:SetValueOnTexture(progress)
-        region.progress = progress;
-
-        local ULx , ULy  = ApplyTransform(0, 0, region)
-        local LLx , LLy  = ApplyTransform(0, progress, region)
-        local LLx_, LLy_ = ApplyTransform(0, 1, region)
-        local URx , URy  = ApplyTransform(1, 0, region)
-        local LRx , LRy  = ApplyTransform(1, progress, region)
-        local LRx_, LRy_ = ApplyTransform(1, 1, region)
-
-        foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
-        foreground:SetHeight(region:GetHeight() * progress);
-        background:SetTexCoord(ULx, ULy, LLx_, LLy_, URx, URy, LRx_, LRy_);
-      end
-    end
-  end
-
-  local function orientCircular(clockwise)
-    local startAngle = region.startAngle % 360; -- Convert 360 to 0
-    local endAngle = region.endAngle % 360;
-
-    if (data.inverse) then
-      clockwise = not clockwise;
-      startAngle = 360 - startAngle;
-      endAngle = 360 - endAngle;
-    end
-    if (endAngle <= startAngle) then
-      endAngle = endAngle + 360;
-    end
-
-    -- start is now 0-359, end 1-719, but at most 360 difference
-
-    region.orientation = clockwise and "CLOCKWISE" or "ANTICLOCKWISE";
-
-    backgroundSpinner:SetProgress(region, startAngle, endAngle, 1, clockwise);
-
-    function region:SetValueOnTexture(progress)
-      progress = progress or 0;
-      region.progress = progress;
-      if (progress < 0) then
-        progress = 0;
-      end
-
-      if (progress > 1) then
-        progress = 1;
-      end
-      foregroundSpinner:SetProgress(region, startAngle, endAngle, progress, clockwise);
-    end
-  end
-
-  local function showCircularProgress()
-    foreground:Hide();
-    background:Hide();
-    foregroundSpinner:Show();
-    backgroundSpinner:Show();
-  end
-
-  local function hideCircularProgress()
-    foreground:Show();
-    background:Show();
-    foregroundSpinner:Hide();
-    backgroundSpinner:Hide();
-  end
-
-  if(data.orientation == "HORIZONTAL_INVERSE") then
-    hideCircularProgress();
-    orientHorizontalInverse();
-  elseif(data.orientation == "HORIZONTAL") then
-    hideCircularProgress();
-    orientHorizontal();
-  elseif(data.orientation == "VERTICAL_INVERSE") then
-    hideCircularProgress();
-    orientVerticalInverse();
-  elseif(data.orientation == "VERTICAL") then
-    hideCircularProgress();
-    orientVertical();
-  elseif(data.orientation == "CLOCKWISE") then
-    showCircularProgress();
-    orientCircular(true);
-  elseif(data.orientation == "ANTICLOCKWISE") then
-    showCircularProgress();
-    orientCircular(false);
-  end
-
-  region:SetValueOnTexture(0.667);
-
-  function region:Scale(scalex, scaley)
-    region.scalex = scalex;
-    region.scaley = scaley;
-    foreground:ClearAllPoints();
-    if(scalex < 0) then
-      region.mirror_h = not data.mirror;
-      scalex = scalex * -1;
-    else
-      region.mirror_h = data.mirror;
-    end
-    if(region.mirror_h) then
-      if(data.orientation == "HORIZONTAL_INVERSE") then
-        foreground:SetPoint("RIGHT", region, "RIGHT");
-      elseif(data.orientation == "HORIZONTAL") then
-        foreground:SetPoint("LEFT", region, "LEFT");
-      end
-    else
-      if(data.orientation == "HORIZONTAL") then
-        foreground:SetPoint("LEFT", region, "LEFT");
-      elseif(data.orientation == "HORIZONTAL_INVERSE") then
-        foreground:SetPoint("RIGHT", region, "RIGHT");
-      end
-    end
-    if(scaley < 0) then
-      region.mirror_v = true;
-      scaley = scaley * -1;
-      if(data.orientation == "VERTICAL_INVERSE") then
-        foreground:SetPoint("TOP", region, "TOP");
-      elseif(data.orientation == "VERTICAL") then
-        foreground:SetPoint("BOTTOM", region, "BOTTOM");
-      end
-    else
-      region.mirror_v = nil;
-      if(data.orientation == "VERTICAL") then
-        foreground:SetPoint("BOTTOM", region, "BOTTOM");
-      elseif(data.orientation == "VERTICAL_INVERSE") then
-        foreground:SetPoint("TOP", region, "TOP");
-      end
-    end
-
-    region:SetWidth(region.width * scalex);
-    region:SetHeight(region.height * scaley);
-
-    local scaleWedge =  1 / 1.4142 * (1 + (data.crop or 0.41));
-    foregroundSpinner:SetWidth(region.width * scaleWedge * scalex);
-    foregroundSpinner:SetHeight(region.height * scaleWedge * scaley);
-    backgroundSpinner:SetWidth((region.width + data.backgroundOffset * 2) * scaleWedge * scalex);
-    backgroundSpinner:SetHeight((region.height + data.backgroundOffset * 2) * scaleWedge * scaley);
-
-    if(data.orientation == "HORIZONTAL_INVERSE" or data.orientation == "HORIZONTAL") then
-      foreground:SetWidth(region.width * scalex * (region.progress or 1));
-      foreground:SetHeight(region.height * scaley);
-    else
-      foreground:SetWidth(region.width * scalex);
-      foreground:SetHeight(region.height * scaley * (region.progress or 1));
-    end
-    background:SetPoint("BOTTOMLEFT", region, "BOTTOMLEFT", -1 * scalex * data.backgroundOffset, -1 * scaley * data.backgroundOffset);
-    background:SetPoint("TOPRIGHT", region, "TOPRIGHT", scalex * data.backgroundOffset, scaley * data.backgroundOffset);
-  end
-
-  function region:Rotate(angle)
-    region.rotation = angle or 0;
-    region.cos_rotation = cos(region.rotation);
-    region.sin_rotation = sin(region.rotation);
-    region:SetValueOnTexture(region.progress);
-  end
-
-  function region:GetRotation()
-    return region.rotation;
-  end
-
-  function region:Color(r, g, b, a)
-    region.color_r = r;
-    region.color_g = g;
-    region.color_b = b;
-    if (r or g or b) then
-      a = a or 1;
-    end
-    region.color_a = a;
-    foreground:SetVertexColor(region.color_anim_r or r, region.color_anim_g or g, region.color_anim_b or b, region.color_anim_a or a);
-    foregroundSpinner:Color(region.color_anim_r or r, region.color_anim_g or g, region.color_anim_b or b, region.color_anim_a or a);
-  end
-
-  function region:ColorAnim(r, g, b, a)
-    region.color_anim_r = r;
-    region.color_anim_g = g;
-    region.color_anim_b = b;
-    region.color_anim_a = a;
-    if (r or g or b) then
-      a = a or 1;
-    end
-    foreground:SetVertexColor(r or region.color_r, g or region.color_g, b or region.color_b, a or region.color_a);
-    foregroundSpinner:Color(r or region.color_r, g or region.color_g, b or region.color_b, a or region.color_a);
-  end
-
-  function region:GetColor()
-    return region.color_r or data.foregroundColor[1], region.color_g or data.foregroundColor[2],
-      region.color_b or data.foregroundColor[3], region.color_a or data.foregroundColor[4];
-  end
-
-  region:Color(data.foregroundColor[1], data.foregroundColor[2], data.foregroundColor[3], data.foregroundColor[4]);
-
-
-  function region:UpdateTime()
-    local progress = 1;
-    if (self.duration ~= 0) then
-      local remaining = self.expirationTime - GetTime()
-      progress = remaining / self.duration
-      local inversed = not self.inverse ~= not region.inverseDirection
-      if(inversed) then
-        progress = 1 - progress;
-      end
-    end
-
-    progress = progress > 0.0001 and progress or 0.0001;
-    if (region.useSmoothProgress) then
-      region.smoothProgress:SetSmoothedValue(progress);
-    else
-      region:SetValueOnTexture(progress);
-    end
-
-    if self.paused and self.FrameTick then
-      self.FrameTick = nil
-      self.subRegionEvents:RemoveSubscriber("FrameTick", region)
-    end
-    if not self.paused and not self.FrameTick then
-      self.FrameTick = FrameTick
-      self.subRegionEvents:AddSubscriber("FrameTick", region)
-    end
-  end
-
-  function region:UpdateValue()
-    local progress = 1
-    if(self.total > 0) then
-      progress = self.value / self.total;
-      if(region.inverseDirection) then
-        progress = 1 - progress;
-      end
-    end
-    progress = progress > 0.0001 and progress or 0.0001;
-    if (region.useSmoothProgress) then
-      region.smoothProgress:SetSmoothedValue(progress);
-    else
-      region:SetValueOnTexture(progress);
-    end
-
-    if self.FrameTick then
-      self.FrameTick = nil
-      self.subRegionEvents:RemoveSubscriber("FrameTick", region)
-    end
-  end
+  region.slanted = data.slanted;
+  region.slant = data.slant;
+  region.slantFirst = data.slantFirst;
+  region.slantMode = data.slantMode;
+  region.auraRotation = data.auraRotation
+  region.texRotation = data.rotation
 
   if region.useSmoothProgress then
     region.PreShow = function()
@@ -924,77 +827,117 @@ local function modify(parent, region, data)
   end
 
   region.FrameTick = nil
-  function region:Update()
-    region:UpdateProgress()
-    local state = region.state
 
-    if state.texture then
-      region:SetTexture(state.texture)
-    end
+  local auraRotationRadians = region.auraRotation / 180 * math.pi
+
+  region.currentTexture = data.foregroundTexture
+
+  Private.LinearProgressTextureBase.modify(region.background, {
+    offset = data.backgroundOffset,
+    texture = data.sameTexture and data.foregroundTexture or data.backgroundTexture,
+    desaturated = data.desaturateBackground,
+    blendMode = data.blendMode,
+    auraRotation = auraRotationRadians,
+    crop_x = region.crop_x,
+    crop_y = region.crop_y,
+    user_x = region.user_x,
+    user_y = region.user_y,
+    mirror = region.mirror,
+    texRotation = region.texRotation,
+    width = data.width,
+    height = data.height
+  })
+
+  background:SetColor(data.backgroundColor[1], data.backgroundColor[2],
+                      data.backgroundColor[3], data.backgroundColor[4])
+
+  Private.LinearProgressTextureBase.modify(region.foreground, {
+    offset = 0,
+    texture = data.foregroundTexture,
+    desaturated = data.desaturateForeground,
+    blendMode = data.blendMode,
+    auraRotation = auraRotationRadians,
+    crop_x = region.crop_x,
+    crop_y = region.crop_y,
+    user_x = region.user_x,
+    user_y = region.user_y,
+    mirror = region.mirror,
+    texRotation = region.texRotation,
+    width = data.width,
+    height = data.height
+  })
+
+  local linearOptions = {
+    offset = 0,
+    texture = data.foregroundTexture,
+    desaturated = false,
+    blendMode = data.blendMode,
+    auraRotation = auraRotationRadians,
+    crop_x = region.crop_x,
+    crop_y = region.crop_y,
+    user_x = region.user_x,
+    user_y = region.user_y,
+    mirror = region.mirror,
+    texRotation = region.texRotation,
+    width = data.width,
+    height = data.height
+  }
+  for _, extraTexture in ipairs(region.extraTextures) do
+    Private.LinearProgressTextureBase.modify(extraTexture, linearOptions)
   end
 
-  function region:SetTexture(texture)
-    region.currentTexture = texture;
-    region.foreground:SetTexture(texture);
-    foregroundSpinner:SetTexture(texture);
-    if (data.sameTexture) then
-      background:SetTexture(texture);
-      backgroundSpinner:SetTexture(texture);
-    end
+  Private.CircularProgressTextureBase.modify(region.foregroundSpinner, {
+    crop_x = region.crop_x,
+    crop_y = region.crop_y,
+    mirror = data.mirror,
+    texRotation = region.texRotation,
+    texture = data.foregroundTexture,
+    blendMode = data.blendMode,
+    desaturated = data.desaturateForeground,
+    auraRotation = auraRotationRadians,
+    width = data.width,
+    height = data.height,
+    offset = 0
+  })
 
-    for _, extraTexture in ipairs(region.extraTextures) do
-      extraTexture:SetTexture(texture);
-    end
+  Private.CircularProgressTextureBase.modify(region.backgroundSpinner, {
+    crop_x = region.crop_x,
+    crop_y = region.crop_y,
+    mirror = data.mirror,
+    texRotation = region.texRotation,
+    texture = data.sameTexture and data.foregroundTexture or data.backgroundTexture,
+    blendMode = data.blendMode,
+    desaturated = data.desaturateBackground,
+    auraRotation = auraRotationRadians,
+    width = data.width,
+    height = data.height,
+    offset = data.backgroundOffset
+  })
 
-    for _, extraSpinner in ipairs(region.extraSpinners) do
-      extraSpinner:SetTexture(texture);
-    end
+  backgroundSpinner:SetColor(data.backgroundColor[1], data.backgroundColor[2],
+                          data.backgroundColor[3], data.backgroundColor[4])
+  backgroundSpinner:SetProgress(region.startAngle, region.endAngle)
+
+  local spinnerOptions = {
+    crop_x = region.crop_x,
+    crop_y = region.crop_y,
+    mirror = data.mirror,
+    texRotation = region.texRotation,
+    texture = data.foregroundTexture,
+    blendMode = data.blendMode,
+    desaturated = false,
+    auraRotation = auraRotationRadians,
+    width = data.width,
+    height = data.height,
+    offset = 0
+  }
+  for _, extraSpinner in ipairs(region.extraSpinners) do
+    Private.CircularProgressTextureBase.modify(extraSpinner, spinnerOptions)
   end
 
-  function region:SetForegroundDesaturated(b)
-    region.foreground:SetDesaturated(b);
-    region.foregroundSpinner:SetDesaturated(b);
-  end
-
-  function region:SetBackgroundDesaturated(b)
-    region.background:SetDesaturated(b);
-    region.backgroundSpinner:SetDesaturated(b);
-  end
-
-  function region:SetBackgroundColor(r, g, b, a)
-    region.background:SetVertexColor(r, g, b, a);
-    region.backgroundSpinner:Color(r, g, b, a);
-  end
-
-  function region:SetRegionWidth(width)
-    region.width = width;
-    region:Scale(region.scalex, region.scaley);
-  end
-
-  function region:SetRegionHeight(height)
-    region.height = height;
-    region:Scale(region.scalex, region.scaley);
-  end
-
-  function region:SetInverse(inverse)
-    if (region.inverseDirection == inverse) then
-      return;
-    end
-    region.inverseDirection = inverse;
-    local progress = 1 - region.progress;
-    progress = progress > 0.0001 and progress or 0.0001;
-    region:SetValueOnTexture(progress);
-  end
-
-  function region:SetOverlayColor(id, r, g, b, a)
-    self.overlays[id] = { r, g, b, a};
-    if (self.extraTextures[id]) then
-      self.extraTextures[id]:SetVertexColor(r, g, b, a);
-    end
-    if (self.extraSpinners[id]) then
-      self.extraSpinners[id]:Color(r, g, b, a);
-    end
-  end
+  region:SetOrientation(data.orientation);
+  region:DoPosition(region)
+  region:Color(data.foregroundColor[1], data.foregroundColor[2], data.foregroundColor[3], data.foregroundColor[4]);
 
   Private.regionPrototype.modifyFinish(parent, region, data);
 end

--- a/WeakAuras/RegionTypes/Texture.lua
+++ b/WeakAuras/RegionTypes/Texture.lua
@@ -109,7 +109,6 @@ local function modify(parent, region, data)
     blendMode = data.blendMode,
     mirror = data.mirror,
     rotation = data.rotation,
-    textureWrapMode = data.textureWrapMode
   })
 
   function region:Scale(scalex, scaley)

--- a/WeakAuras/SubRegionTypes/CircularProgressTexture.lua
+++ b/WeakAuras/SubRegionTypes/CircularProgressTexture.lua
@@ -1,0 +1,308 @@
+if not WeakAuras.IsLibsOK() then return end
+local AddonName = ...
+local Private = select(2, ...)
+
+local L = WeakAuras.L
+
+local default = function(parentType)
+  local defaults = {
+    circularTextureVisible = true,
+
+    circularTextureTexture = "Interface\\AddOns\\WeakAuras\\Media\\Textures\\square_border_5px.tga",
+    circularTextureDesaturate = false,
+    circularTextureColor = {1, 1, 1, 1},
+    circularTextureBlendMode = "BLEND",
+    circularTextureStartAngle = 0,
+    circularTextureEndAngle = 360,
+    circularTextureClockwise = true,
+
+    circularTextureCrop_x = 0.41,
+    circularTextureCrop_y = 0.41,
+    circularTextureRotation = 0, -- Uses tex coord rotation, called "legacy rotation" in the ui and texRotation in code everywhere else
+    circularTextureAuraRotation = 0, -- Uses texture:SetRotation
+    circularTextureMirror = false,
+
+    anchor_mode = "area",
+    self_point = "CENTER",
+    anchor_point = "CENTER",
+    width = 32,
+    height = 32,
+    scale = 1,
+
+    progressSource = {-2, ""},
+  }
+
+  if parentType == "aurabar" then
+    defaults.anchor_area = "bar"
+  else
+    defaults.anchor_area = "ALL"
+  end
+
+  return defaults
+end
+
+local properties = {
+  circularTextureVisible = {
+    display = L["Visibility"],
+    setter = "SetVisible",
+    type = "bool",
+    defaultProperty = true
+  },
+  circularTextureDesaturate = {
+    display = L["Desaturate"],
+    setter = "SetDesaturated",
+    type = "bool",
+  },
+
+  circularTextureInverse = {
+    display = L["Inverse"],
+    setter = "SetInverse",
+    type = "bool",
+  },
+  circularTextureColor = {
+    display = L["Color"],
+    setter = "SetColor",
+    type = "color"
+  },
+  circularTextureClockwise = {
+    display = L["Clockwise"],
+    setter = "SetClockwise",
+    type = "bool",
+  },
+  circularTextureAuraRotation = {
+    display = L["Rotation"],
+    setter = "SetAuraRotation",
+    type = "number",
+    min = 0,
+    max = 360,
+    bigStep = 10,
+    default = 0
+  },
+  circularTextureMirror = {
+    display = L["Mirror"],
+    setter = "SetMirror",
+    type = "bool",
+  },
+  circularTextureCrop_x = {
+    display = L["Crop X"],
+    setter = "SetCropX",
+    type = "number",
+    min = 0,
+    softMax = 2,
+    bigStep = 0.01,
+    isPercent = true,
+  },
+  circularTextureCrop_y = {
+    display = L["Crop Y"],
+    setter = "SetCropY",
+    type = "number",
+    min = 0,
+    softMax = 2,
+    bigStep = 0.01,
+    isPercent = true,
+  },
+}
+
+
+local funcs = {
+  SetDesaturated = function(self, b)
+    self.circularTexture:SetDesaturated(b)
+  end,
+  SetColor = function(self, ...)
+    self.circularTexture:SetColor(...)
+  end,
+  SetVisible = function(self, b)
+    self.visible = b
+    if b then
+      self.circularTexture:Show()
+      self:UpdateFrame()
+    else
+      self.circularTexture:Hide()
+    end
+    self:UpdateFrameTick()
+  end,
+  SetAuraRotation = function(self, degrees)
+    self.circularTexture:SetAuraRotation(degrees / 180 * math.pi)
+  end,
+  SetMirror = function(self, b)
+    self.circularTexture:SetMirror(b)
+  end,
+  SetCropX = function(self, cropX)
+    self.circularTexture:SetCropX(1 + cropX)
+  end,
+  SetCropY = function(self, cropY)
+    self.circularTexture:SetCropY(1 + cropY)
+  end,
+  UpdateFrameTick = function(self)
+    if self.visible and self.progressData.progressType == "timed" and not self.progressData.paused then
+      if not self.FrameTick then
+        self.FrameTick = self.UpdateFrame
+
+        self.parent.subRegionEvents:AddSubscriber("FrameTick", self)
+      end
+    else
+      if self.FrameTick then
+        self.FrameTick = nil
+        self.parent.subRegionEvents:RemoveSubscriber("FrameTick", self)
+      end
+    end
+  end,
+  SetAngles = function(self, startAngle, endAngle)
+    self.startAngle = startAngle
+    self.endAngle = endAngle
+  end,
+  ProgressToAnglesClockwise = function(self, progress)
+    progress = Clamp(progress, 0, 1)
+    local pAngle = (self.endAngle - self.startAngle) * progress + self.startAngle
+    return self.startAngle, pAngle
+  end,
+  ProgressToAnglesAntiClockwise = function(self, progress)
+    progress = Clamp(progress, 0, 1)
+    progress = 1 - progress
+    local pAngle = (self.endAngle - self.startAngle) * progress + self.startAngle
+    return pAngle, self.endAngle
+  end,
+  SetClockwise = function(self, b)
+    if b then
+      self.ProgressToAngles = self.ProgressToAnglesClockwise
+    else
+      self.ProgressToAngles = self.ProgressToAnglesAntiClockwise
+    end
+    self:UpdateFrame()
+  end,
+  UpdateFrame = function(self)
+    if self.visible then
+      local progressData = self.progressData
+      if progressData.progressType == "static" then
+        local progress = 0
+        if progressData.total ~= 0 then
+          progress = progressData.value / progressData.total
+        end
+        if self.inverse then
+          progress = 1 - progress
+        end
+        self.circularTexture:SetProgress(self:ProgressToAngles(progress))
+      elseif progressData.progressType == "timed" then
+        if progressData.paused then
+          local remaining = self.progressData.remaining
+          local duration = self.progressData.duration
+          local progress
+          if duration == 0 then
+            progress = 0
+          else
+            progress = remaining / duration
+            if self.inverse then
+              progress = 1 - progress
+            end
+          end
+          self.circularTexture:SetProgress(self:ProgressToAngles(progress))
+        else
+          local remaining = self.progressData.expirationTime - GetTime()
+          local progress = remaining / self.progressData.duration
+          if self.inverse then
+            progress = 1 - progress
+          end
+          self.circularTexture:SetProgress(self:ProgressToAngles(progress))
+        end
+      end
+    end
+  end,
+  Update = function(self, state, states)
+    Private.UpdateProgressFrom(self.progressData, self.progressSource, self, state, states, self.parent)
+    self:UpdateFrame()
+    self:UpdateFrameTick()
+  end,
+  OnSizeChanged = function(self)
+    local w, h = self:GetSize()
+    self.circularTexture:SetWidth(w)
+    self.circularTexture:SetHeight(h)
+    self.circularTexture:UpdateTextures()
+  end,
+  SetInverse = function(self, inverse)
+    self.inverse = inverse
+    self:UpdateFrame()
+  end
+}
+
+local function create()
+  local region = CreateFrame("Frame", nil, UIParent)
+  region:SetFlattensRenderLayers(true)
+
+  for k, v in pairs(funcs) do
+    region[k] = v
+  end
+
+  region.circularTexture = Private.CircularProgressTextureBase.create(region, "ARTWORK", 1)
+  region.progressData = {}
+  region:SetScript("OnSizeChanged", region.OnSizeChanged)
+
+  return region
+end
+
+local function onAcquire(subRegion)
+  subRegion:Show()
+end
+
+local function onRelease(subRegion)
+  subRegion:Hide()
+end
+
+local function modify(parent, region, parentData, data, first)
+  region.parent = parent
+  region:SetParent(parent)
+  region.scale = data.scale or 1
+  region.Anchor = nil
+
+  local arg1 = data.anchor_mode == "point" and data.anchor_point or data.anchor_area
+  local arg2 = data.anchor_mode == "point" and data.self_point or nil
+
+  if data.anchor_mode == "point" then
+    region:SetSize(data.width or 0, data.height or 0)
+  end
+
+
+  region.Anchor = function()
+    region:ClearAllPoints()
+    parent:AnchorSubRegion(region, data.anchor_mode, arg1, arg2, data.xOffset, data.yOffset)
+    region:OnSizeChanged()
+  end
+
+  region.inverse = data.circularTextureInverse
+
+  Private.CircularProgressTextureBase.modify(region.circularTexture, {
+    crop_x = 1 + data.circularTextureCrop_x,
+    crop_y = 1 + data.circularTextureCrop_y,
+    texRotation = data.circularTextureRotation,
+    auraRotation = data.circularTextureAuraRotation / 180 * math.pi,
+    mirror = data.circularTextureMirror,
+    desaturated = data.circularTextureDesaturate,
+    blendMode = data.circularTextureBlendMode,
+    texture = data.circularTextureTexture,
+    -- width and height will be set via the anchoring function
+    width = 0,
+    height = 0,
+    offset = 0
+  })
+
+  Private.regionPrototype.AddMinMaxProgressSource(true, region, parentData, data)
+
+  region.FrameTick = nil
+  parent.subRegionEvents:AddSubscriber("Update", region)
+
+  region:SetVisible(data.circularTextureVisible)
+  region:SetAngles(data.circularTextureStartAngle, data.circularTextureEndAngle)
+  region:SetClockwise(data.circularTextureClockwise)
+  region:SetColor(data.circularTextureColor[1], data.circularTextureColor[2],
+                  data.circularTextureColor[3], data.circularTextureColor[4])
+end
+
+local function supports(regionType)
+  return regionType == "texture"
+         or regionType == "progresstexture"
+         or regionType == "icon"
+         or regionType == "aurabar"
+         or regionType == "text"
+end
+
+WeakAuras.RegisterSubRegionType("subcirculartexture", L["Circular Texture"], supports, create, modify, onAcquire, onRelease,
+                                default, nil, properties)

--- a/WeakAuras/SubRegionTypes/CircularProgressTexture.lua
+++ b/WeakAuras/SubRegionTypes/CircularProgressTexture.lua
@@ -226,7 +226,6 @@ local funcs = {
 
 local function create()
   local region = CreateFrame("Frame", nil, UIParent)
-  region:SetFlattensRenderLayers(true)
 
   for k, v in pairs(funcs) do
     region[k] = v

--- a/WeakAuras/SubRegionTypes/LinearProgressTexture.lua
+++ b/WeakAuras/SubRegionTypes/LinearProgressTexture.lua
@@ -197,7 +197,6 @@ local funcs = {
 
 local function create()
   local region = CreateFrame("Frame", nil, UIParent)
-  region:SetFlattensRenderLayers(true)
 
   for k, v in pairs(funcs) do
     region[k] = v

--- a/WeakAuras/SubRegionTypes/LinearProgressTexture.lua
+++ b/WeakAuras/SubRegionTypes/LinearProgressTexture.lua
@@ -1,0 +1,282 @@
+if not WeakAuras.IsLibsOK() then return end
+local AddonName = ...
+local Private = select(2, ...)
+
+local L = WeakAuras.L
+
+local default = function(parentType)
+  local defaults = {
+    linearTextureVisible = true,
+    linearTextureTexture = "Interface\\AddOns\\WeakAuras\\Media\\Textures\\Square_FullWhite",
+    linearTextureDesaturate = false,
+    linearTextureColor = {1, 1, 1, 1},
+    linearTextureBlendMode = "BLEND",
+    linearTextureOrientation = "HORIZONTAL",
+
+    linearTextureUser_x = 0,
+    linearTextureUser_y = 0,
+    linearTextureCrop_x = 0.41,
+    linearTextureCrop_y = 0.41,
+    linearTextureRotation = 0, -- Uses tex coord rotation, called "legacy rotation" in the ui and texRotation in code everywhere else
+    linearTextureAuraRotation = 0, -- Uses texture:SetRotation
+    linearTextureMirror = false,
+
+    anchor_mode = "area",
+    self_point = "CENTER",
+    anchor_point = "CENTER",
+    width = 32,
+    height = 32,
+    scale = 1,
+
+    progressSource = {-2, ""},
+  }
+
+  if parentType == "aurabar" then
+    defaults.anchor_area = "bar"
+  else
+    defaults.anchor_area = "ALL"
+  end
+
+  return defaults
+end
+
+local properties = {
+  linearTextureVisible = {
+    display = L["Visibility"],
+    setter = "SetVisible",
+    type = "bool",
+    defaultProperty = true
+  },
+  linearTextureDesaturate = {
+    display = L["Desaturate"],
+    setter = "SetDesaturated",
+    type = "bool",
+  },
+
+  linearTextureInverse = {
+    display = L["Inverse"],
+    setter = "SetInverse",
+    type = "bool",
+  },
+  linearTextureColor = {
+    display = L["Color"],
+    setter = "SetColor",
+    type = "color"
+  },
+  linearTextureAuraRotation = {
+    display = L["Rotation"],
+    setter = "SetAuraRotation",
+    type = "number",
+    min = 0,
+    max = 360,
+    bigStep = 10,
+    default = 0
+  },
+  linearTextureMirror = {
+    display = L["Mirror"],
+    setter = "SetMirror",
+    type = "bool",
+  },
+  linearTextureCrop_x = {
+    display = L["Crop X"],
+    setter = "SetCropX",
+    type = "number",
+    min = 0,
+    softMax = 2,
+    bigStep = 0.01,
+    isPercent = true,
+  },
+  linearTextureCrop_y = {
+    display = L["Crop Y"],
+    setter = "SetCropY",
+    type = "number",
+    min = 0,
+    softMax = 2,
+    bigStep = 0.01,
+    isPercent = true,
+  },
+}
+
+
+local funcs = {
+  SetDesaturated = function(self, b)
+    self.linearTexture:SetDesaturated(b)
+  end,
+  SetColor = function(self, ...)
+    self.linearTexture:SetColor(...)
+  end,
+  SetVisible = function(self, b)
+    self.visible = b
+    if b then
+      self.linearTexture:Show()
+      self:UpdateFrame()
+    else
+      self.linearTexture:Hide()
+    end
+    self:UpdateFrameTick()
+  end,
+  SetAuraRotation = function(self, degrees)
+    self.linearTexture:SetAuraRotation(degrees / 180 * math.pi)
+  end,
+  SetMirror = function(self, b)
+    self.linearTexture:SetMirror(b)
+  end,
+  SetCropX = function(self, cropX)
+    self.linearTexture:SetCropX(1 + cropX)
+  end,
+  SetCropY = function(self, cropY)
+    self.linearTexture:SetCropY(1 + cropY)
+  end,
+  UpdateFrameTick = function(self)
+    if self.visible and self.progressData.progressType == "timed" and not self.progressData.paused then
+      if not self.FrameTick then
+        self.FrameTick = self.UpdateFrame
+
+        self.parent.subRegionEvents:AddSubscriber("FrameTick", self)
+      end
+    else
+      if self.FrameTick then
+        self.FrameTick = nil
+        self.parent.subRegionEvents:RemoveSubscriber("FrameTick", self)
+      end
+    end
+  end,
+  UpdateFrame = function(self)
+    if self.visible then
+      local progressData = self.progressData
+      if progressData.progressType == "static" then
+        local progress = 0
+        if progressData.total ~= 0 then
+          progress = progressData.value / progressData.total
+        end
+        if self.inverse then
+          progress = 1 - progress
+        end
+        self.linearTexture:SetValue(0, progress)
+      elseif progressData.progressType == "timed" then
+        if progressData.paused then
+          local remaining = self.progressData.remaining
+          local duration = self.progressData.duration
+          local progress
+          if duration == 0 then
+            progress = 0
+          else
+            progress = remaining / duration
+            if self.inverse then
+              progress = 1 - progress
+            end
+          end
+          self.linearTexture:SetValue(0, progress)
+        else
+          local remaining = self.progressData.expirationTime - GetTime()
+          local progress = remaining / self.progressData.duration
+          if self.inverse then
+            progress = 1 - progress
+          end
+          self.linearTexture:SetValue(0, progress)
+        end
+      end
+    end
+  end,
+  Update = function(self, state, states)
+    Private.UpdateProgressFrom(self.progressData, self.progressSource, self, state, states, self.parent)
+    self:UpdateFrame()
+    self:UpdateFrameTick()
+  end,
+  OnSizeChanged = function(self)
+    local w, h = self:GetSize()
+    self.linearTexture:SetWidth(w)
+    self.linearTexture:SetHeight(h)
+    self.linearTexture:UpdateTextures()
+  end,
+  SetInverse = function(self, inverse)
+    self.inverse = inverse
+    self:UpdateFrame()
+  end
+}
+
+local function create()
+  local region = CreateFrame("Frame", nil, UIParent)
+  region:SetFlattensRenderLayers(true)
+
+  for k, v in pairs(funcs) do
+    region[k] = v
+  end
+
+  region.linearTexture = Private.LinearProgressTextureBase.create(region, "ARTWORK", 1)
+  region.progressData = {}
+  region:SetScript("OnSizeChanged", region.OnSizeChanged)
+
+  return region
+end
+
+local function onAcquire(subRegion)
+  subRegion:Show()
+end
+
+local function onRelease(subRegion)
+  subRegion:Hide()
+end
+
+local function modify(parent, region, parentData, data, first)
+  region.parent = parent
+  region:SetParent(parent)
+  region.scale = data.scale or 1
+  region.Anchor = nil
+
+  local arg1 = data.anchor_mode == "point" and data.anchor_point or data.anchor_area
+  local arg2 = data.anchor_mode == "point" and data.self_point or nil
+
+  if data.anchor_mode == "point" then
+    region:SetSize(data.width or 0, data.height or 0)
+  end
+
+  region.inverse = data.linearTextureInverse
+
+  region.Anchor = function()
+    region:ClearAllPoints()
+    parent:AnchorSubRegion(region, data.anchor_mode, arg1, arg2, data.xOffset, data.yOffset)
+    region:OnSizeChanged()
+  end
+
+  region.linearTexture:Hide()
+
+  Private.LinearProgressTextureBase.modify(region.linearTexture, {
+    user_x = -1 * (data.linearTextureUser_x or 0),
+    user_y = data.linearTextureUser_y or 0,
+    crop_x = 1 + data.linearTextureCrop_x,
+    crop_y = 1 + data.linearTextureCrop_y,
+    texRotation = data.linearTextureRotation,
+    auraRotation = data.linearTextureAuraRotation / 180 * math.pi,
+    mirror = data.linearTextureMirror,
+    desaturated = data.linearTextureDesaturate,
+    blendMode = data.linearTextureBlendMode,
+    texture = data.linearTextureTexture,
+    -- width and height will be set via the anchoring function
+    width = 0,
+    height = 0,
+    offset = 0
+  })
+
+  region.linearTexture:SetOrientation(data.linearTextureOrientation, false, false, 0, false, nil)
+
+  Private.regionPrototype.AddMinMaxProgressSource(true, region, parentData, data)
+
+  region.FrameTick = nil
+  parent.subRegionEvents:AddSubscriber("Update", region)
+
+  region:SetVisible(data.linearTextureVisible)
+  region:SetColor(data.linearTextureColor[1], data.linearTextureColor[2],
+                  data.linearTextureColor[3], data.linearTextureColor[4])
+end
+
+local function supports(regionType)
+  return regionType == "texture"
+         or regionType == "progresstexture"
+         or regionType == "icon"
+         or regionType == "aurabar"
+         or regionType == "text"
+end
+
+WeakAuras.RegisterSubRegionType("sublineartexture", L["Linear Texture"], supports, create, modify, onAcquire, onRelease,
+                                default, nil, properties)

--- a/WeakAuras/SubRegionTypes/StopMotion.lua
+++ b/WeakAuras/SubRegionTypes/StopMotion.lua
@@ -162,7 +162,6 @@ local ProgressFuncs = {
 
 local function create()
   local region = CreateFrame("Frame", nil, UIParent)
-  --region:SetFlattensRenderLayers(true)
 
   for k, v in pairs(funcs) do
     region[k] = v

--- a/WeakAuras/SubRegionTypes/Texture.lua
+++ b/WeakAuras/SubRegionTypes/Texture.lua
@@ -138,7 +138,6 @@ local function modify(parent, region, parentData, data, first)
     blendMode = data.textureBlendMode,
     mirror = data.textureMirror,
     rotation = data.textureRotation,
-    textureWrapMode = "CLAMPTOBLACKADDITIVE"
   })
 
   region:SetVisible(data.textureVisible)

--- a/WeakAuras/SubRegionTypes/Texture.lua
+++ b/WeakAuras/SubRegionTypes/Texture.lua
@@ -94,7 +94,6 @@ local funcs = {
 
 local function create()
   local region = CreateFrame("Frame", nil, UIParent)
-  --region:SetFlattensRenderLayers(true)
 
   for k, v in pairs(funcs) do
     region[k] = v

--- a/WeakAuras/WeakAuras.toc
+++ b/WeakAuras/WeakAuras.toc
@@ -66,6 +66,9 @@ DebugLog.lua
 # Region support
 RegionTypes\SmoothStatusBarMixin.lua
 RegionTypes\RegionPrototype.lua
+BaseRegions\TextureCoords.lua
+BaseRegions\CircularProgressTexture.lua
+BaseRegions\LinearProgressTexture.lua
 RegionTypes\Empty.lua
 RegionTypes\ProgressTexture.lua
 BaseRegions\Texture.lua
@@ -88,6 +91,8 @@ SubRegionTypes\Tick.lua
 SubRegionTypes\Model.lua
 SubRegionTypes\StopMotion.lua
 SubRegionTypes\Texture.lua
+SubRegionTypes\CircularProgressTexture.lua
+SubRegionTypes\LinearProgressTexture.lua
 
 #Misc
 DiscordList.lua

--- a/WeakAurasOptions/RegionOptions/ProgressTexture.lua
+++ b/WeakAurasOptions/RegionOptions/ProgressTexture.lua
@@ -28,10 +28,11 @@ local function createOptions(id, data)
         OptionsPrivate.OpenTexturePicker(data, paths, {
           texture = "foregroundTexture",
           color = "foregroundColor",
-          rotation = "rotation",
+          texRotation = "rotation",
+          auraRotation = "auraRotation",
           mirror = "mirror",
           blendMode = "blendMode"
-        }, OptionsPrivate.Private.texture_types);
+        }, OptionsPrivate.Private.texture_types)
       end,
       imageWidth = 24,
       imageHeight = 24,
@@ -60,10 +61,11 @@ local function createOptions(id, data)
         OptionsPrivate.OpenTexturePicker(data, paths, {
           texture = "backgroundTexture",
           color = "backgroundColor",
-          rotation = "rotation",
+          texRotation = "rotation",
+          auraRotation = "auraRotation",
           mirror = "mirror",
           blendMode = "blendMode"
-        }, OptionsPrivate.Private.texture_types);
+        }, OptionsPrivate.Private.texture_types)
       end,
       disabled = function() return data.sameTexture; end,
       imageWidth = 24,
@@ -227,16 +229,6 @@ local function createOptions(id, data)
         OptionsPrivate.ResetMoverSizer();
       end,
     },
-    rotation = {
-      type = "range",
-      control = "WeakAurasSpinBox",
-      width = WeakAuras.normalWidth,
-      name = L["Rotation"],
-      order = 52,
-      min = 0,
-      max = 360,
-      bigStep = 1
-    },
     alpha = {
       type = "range",
       control = "WeakAurasSpinBox",
@@ -247,6 +239,27 @@ local function createOptions(id, data)
       max = 1,
       bigStep = 0.01,
       isPercent = true
+    },
+    rotation = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      name = L["Texture Rotation"],
+      desc = L["Uses Texture Coordinates to rotate the texture."],
+      order = 52,
+      min = 0,
+      max = 360,
+      bigStep = 1
+    },
+    auraRotation = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      name = L["Rotation"],
+      order = 53,
+      min = 0,
+      max = 360,
+      bigStep = 1
     },
     smoothProgress = {
       type = "toggle",
@@ -381,10 +394,6 @@ local function ApplyTransform(x, y, region)
   end
 
   -- 5) Rotate texture by user-defined value
-  --[[local x_tmp = region.cos_rotation * x - region.sin_rotation * y
-  local y_tmp = region.sin_rotation * x + region.cos_rotation * y
-  x = x_tmp
-  y = y_tmp]]
   x, y = region.cos_rotation * x - region.sin_rotation * y, region.sin_rotation * x + region.cos_rotation * y
 
   -- 6) Translate texture-coords back to (0,0)
@@ -427,8 +436,8 @@ local function createThumbnail()
   local foreground = region:CreateTexture(nil, "ARTWORK");
   borderframe.foreground = foreground;
 
-  borderframe.backgroundSpinner = WeakAuras.createSpinner(region, "BACKGROUND", region:GetFrameLevel() + 1);
-  borderframe.foregroundSpinner = WeakAuras.createSpinner(region, "ARTWORK", region:GetFrameLevel() + 2);
+  borderframe.backgroundSpinner = OptionsPrivate.Private.CircularProgressTextureBase.create(region, "BACKGROUND", 1)
+  borderframe.foregroundSpinner = OptionsPrivate.Private.CircularProgressTextureBase.create(region, "ARTWORK", 1)
 
   return borderframe;
 end
@@ -445,10 +454,6 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
     region:SetHeight(size);
     foreground:SetWidth(scale * data.width);
     foreground:SetHeight(size);
-    foregroundSpinner:SetWidth(scale * data.width);
-    foregroundSpinner:SetHeight(size);
-    backgroundSpinner:SetWidth(scale * data.width)
-    backgroundSpinner:SetHeight(size);
     region.width = scale * data.width;
     region.height = size;
   else
@@ -457,10 +462,6 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
     region:SetHeight(scale * data.height);
     foreground:SetWidth(size);
     foreground:SetHeight(scale * data.height);
-    foregroundSpinner:SetWidth(size);
-    foregroundSpinner:SetHeight(scale * data.height);
-    backgroundSpinner:SetWidth(size)
-    backgroundSpinner:SetHeight(scale * data.height);
     region.width = size;
     region.height = scale * data.height;
   end
@@ -473,18 +474,18 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
   background:SetVertexColor(data.backgroundColor[1], data.backgroundColor[2], data.backgroundColor[3], data.backgroundColor[4]);
   background:SetBlendMode(data.blendMode);
 
-  backgroundSpinner:SetTexture(data.sameTexture and data.foregroundTexture or data.backgroundTexture);
+  backgroundSpinner:SetTextureOrAtlas(data.sameTexture and data.foregroundTexture or data.backgroundTexture);
   backgroundSpinner:SetDesaturated(data.desaturateBackground)
-  backgroundSpinner:Color(data.backgroundColor[1], data.backgroundColor[2], data.backgroundColor[3], data.backgroundColor[4]);
+  backgroundSpinner:SetColor(data.backgroundColor[1], data.backgroundColor[2], data.backgroundColor[3], data.backgroundColor[4]);
   backgroundSpinner:SetBlendMode(data.blendMode);
 
   foreground:SetTexture(data.foregroundTexture);
   foreground:SetVertexColor(data.foregroundColor[1], data.foregroundColor[2], data.foregroundColor[3], data.foregroundColor[4]);
   foreground:SetBlendMode(data.blendMode);
 
-  foregroundSpinner:SetTexture(data.foregroundTexture);
+  foregroundSpinner:SetTextureOrAtlas(data.foregroundTexture);
   foregroundSpinner:SetDesaturated(data.desaturateForeground);
-  foregroundSpinner:Color(data.foregroundColor[1], data.foregroundColor[2], data.foregroundColor[3], data.foregroundColor[4])
+  foregroundSpinner:SetColor(data.foregroundColor[1], data.foregroundColor[2], data.foregroundColor[3], data.foregroundColor[4])
   foregroundSpinner:SetBlendMode(data.blendMode);
 
   background:ClearAllPoints();
@@ -495,9 +496,10 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
   region.mirror_h = data.mirror;
   region.scale_x = 1 + (data.crop_x or 0.41);
   region.scale_y = 1 + (data.crop_y or 0.41);
-  region.rotation = data.rotation or 0;
-  region.cos_rotation = cos(region.rotation);
-  region.sin_rotation = sin(region.rotation);
+  region.texRotation = data.rotation or 0
+  region.auraRotation = data.auraRotation or 0
+  region.cos_rotation = cos(region.texRotation)
+  region.sin_rotation = sin(region.texRotation)
   region.user_x = -1 * (data.user_x or 0);
   region.user_y = data.user_y or 0;
   region.aspect = 1;
@@ -517,7 +519,9 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
 
         foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
         foreground:SetWidth(region:GetWidth() * progress);
+        foreground:SetRotation(region.auraRotation / 180 * math.pi)
         background:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
+        background:SetRotation(region.auraRotation / 180 * math.pi)
       end
     else
       function region:SetValue(progress)
@@ -532,7 +536,9 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
 
         foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx , URy , LRx , LRy );
         foreground:SetWidth(region:GetWidth() * progress);
+        foreground:SetRotation(region.auraRotation / 180 * math.pi)
         background:SetTexCoord(ULx, ULy, LLx, LLy, URx_, URy_, LRx_, LRy_);
+        background:SetRotation(region.auraRotation / 180 * math.pi)
       end
     end
   end
@@ -551,7 +557,9 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
 
         foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
         foreground:SetWidth(region:GetWidth() * progress);
+        foreground:SetRotation(region.auraRotation / 180 * math.pi)
         background:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
+        background:SetRotation(region.auraRotation / 180 * math.pi)
       end
     else
       function region:SetValue(progress)
@@ -566,7 +574,9 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
 
         foreground:SetTexCoord(ULx , ULy , LLx , LLy , URx, URy, LRx, LRy);
         foreground:SetWidth(region:GetWidth() * progress);
+        foreground:SetRotation(region.auraRotation / 180 * math.pi)
         background:SetTexCoord(ULx_, ULy_, LLx_, LLy_, URx, URy, LRx, LRy);
+        background:SetRotation(region.auraRotation / 180 * math.pi)
       end
     end
   end
@@ -586,7 +596,9 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
 
         foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
         foreground:SetHeight(region:GetHeight() * progress);
+        foreground:SetRotation(region.auraRotation / 180 * math.pi)
         background:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
+        background:SetRotation(region.auraRotation / 180 * math.pi)
       end
     else
       function region:SetValue(progress)
@@ -601,7 +613,9 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
 
         foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
         foreground:SetHeight(region:GetHeight() * progress);
+        foreground:SetRotation(region.auraRotation / 180 * math.pi)
         background:SetTexCoord(ULx_, ULy_, LLx, LLy, URx_, URy_, LRx, LRy);
+        background:SetRotation(region.auraRotation / 180 * math.pi)
       end
     end
   end
@@ -621,7 +635,9 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
 
         foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
         foreground:SetHeight(region:GetHeight() * progress);
+        foreground:SetRotation(region.auraRotation / 180 * math.pi)
         background:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
+        background:SetRotation(region.auraRotation / 180 * math.pi)
       end
     else
       function region:SetValue(progress)
@@ -636,7 +652,9 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
 
         foreground:SetTexCoord(ULx, ULy, LLx, LLy, URx, URy, LRx, LRy);
         foreground:SetHeight(region:GetHeight() * progress);
+        foreground:SetRotation(region.auraRotation / 180 * math.pi)
         background:SetTexCoord(ULx, ULy, LLx_, LLy_, URx, URy, LRx_, LRy_);
+        background:SetRotation(region.auraRotation / 180 * math.pi)
       end
     end
   end
@@ -645,23 +663,39 @@ local function modifyThumbnail(parent, borderframe, data, fullModify, size)
     local startAngle = data.startAngle % 360;
     local endAngle = data.endAngle % 360;
 
-    if (data.inverse) then
-      startAngle, endAngle = endAngle, startAngle
-      startAngle = 360 - startAngle;
-      endAngle = 360 - endAngle;
-      clockwise = not clockwise;
-    end
     if (endAngle <= startAngle) then
       endAngle = endAngle + 360;
     end
 
-    backgroundSpinner:SetProgress(region, startAngle, endAngle, 0, clockwise);
+    backgroundSpinner:SetWidth(30)
+    backgroundSpinner:SetHeight(30)
+    foregroundSpinner:SetWidth(30)
+    foregroundSpinner:SetHeight(30)
+    backgroundSpinner:SetProgress(startAngle, endAngle);
+    foregroundSpinner:SetProgress(startAngle, endAngle);
 
     function region:SetValue(progress)
-      progress = progress or 0;
       region.progress = progress;
 
-      foregroundSpinner:SetProgress(region, startAngle, endAngle, progress, clockwise);
+      if (progress < 0) then
+        progress = 0;
+      end
+
+      if (progress > 1) then
+        progress = 1;
+      end
+
+      if (not clockwise) then
+        progress = 1 - progress;
+      end
+
+      local pAngle = (endAngle - startAngle) * progress + startAngle;
+
+      if (clockwise) then
+        foregroundSpinner:SetProgress(startAngle, pAngle);
+      else
+        foregroundSpinner:SetProgress(pAngle, endAngle);
+      end
     end
   end
 
@@ -750,7 +784,7 @@ local templates = {
       xOffset = 0,
       yOffset = 150,
       mirror = true,
-      foregroundTexture = "Textures\\SpellActivationOverlays\\Backlash",
+      foregroundTexture = "Textures\\SpellActivationOverlays\\Backlash", -- "460830"
       orientation = "HORIZONTAL",
       inverse = true,
     },

--- a/WeakAurasOptions/SubRegionOptions/CircularProgressTexture.lua
+++ b/WeakAurasOptions/SubRegionOptions/CircularProgressTexture.lua
@@ -1,0 +1,165 @@
+if not WeakAuras.IsLibsOK() then return end
+local AddonName = ...
+local OptionsPrivate = select(2, ...)
+
+local L = WeakAuras.L;
+
+local function createOptions(parentData, data, index, subIndex)
+  local pointAnchors = {}
+  local areaAnchors = {}
+  for child in OptionsPrivate.Private.TraverseLeafsOrAura(parentData) do
+    WeakAuras.Mixin(pointAnchors, OptionsPrivate.Private.GetAnchorsForData(child, "point"))
+    WeakAuras.Mixin(areaAnchors, OptionsPrivate.Private.GetAnchorsForData(child, "area"))
+  end
+
+  local options = {
+    __title = L["Circular Texture %s"]:format(subIndex),
+    __order = 1,
+    circularTextureVisible = {
+      type = "toggle",
+      width = WeakAuras.doubleWidth,
+      name = L["Show Circular Texture"],
+      order = 1,
+    },
+    circularTextureTexture = {
+      type = "input",
+      width = WeakAuras.doubleWidth - 0.15,
+      name = L["Texture"],
+      order = 2,
+    },
+    chooseTexture = {
+      type = "execute",
+      width = 0.15,
+      name = L["Choose"],
+      order = 3,
+      func = function()
+        local path = { "subRegions", index }
+        local paths = {}
+        for child in OptionsPrivate.Private.TraverseLeafsOrAura(parentData) do
+          paths[child.id] = path
+        end
+        OptionsPrivate.OpenTexturePicker(parentData, paths, {
+          texture = "circularTextureTexture",
+          color = "circularTextureColor",
+          blendMode = "circularTextureBlendMode"
+        }, OptionsPrivate.Private.texture_types)
+      end,
+      imageWidth = 24,
+      imageHeight = 24,
+      control = "WeakAurasIcon",
+      image = "Interface\\AddOns\\WeakAuras\\Media\\Textures\\browse",
+    },
+    circularTextureClockwise = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Clockwise"],
+      order = 4,
+    },
+    circularTextureMirror = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Mirror"],
+      order = 5,
+    },
+    circularTextureColor = {
+      type = "color",
+      width = WeakAuras.normalWidth,
+      name = L["Color"],
+      hasAlpha = true,
+      order = 6
+    },
+    circularTextureDesaturate = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Desaturate"],
+      order = 7,
+    },
+    circularTextureBlendMode = {
+      type = "select",
+      width = WeakAuras.normalWidth,
+      name = L["Blend Mode"],
+      order = 8,
+      values = OptionsPrivate.Private.blend_types
+    },
+    circularTextureInverse = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Inverse"],
+      order = 8.5,
+    },
+    circularTextureStartAngle = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      order = 9,
+      name = L["Start Angle"],
+      min = 0,
+      max = 360,
+      bigStep = 1,
+    },
+    circularTextureEndAngle = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      order = 10,
+      name = L["End Angle"],
+      min = 0,
+      max = 360,
+      bigStep = 1,
+     },
+     circularTextureCrop_x = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      name = L["Crop X"],
+      order = 11,
+      min = 0,
+      softMax = 2,
+      bigStep = 0.01,
+      isPercent = true,
+    },
+    circularTextureCrop_y = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      name = L["Crop Y"],
+      order = 12,
+      min = 0,
+      softMax = 2,
+      bigStep = 0.01,
+      isPercent = true,
+    },
+    -- Doesn't appear to work
+    circularTextureRotation = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      name = L["Texture Rotation"],
+      desc = L["Uses Texture Coordinates to rotate the texture."],
+      order = 13,
+      min = 0,
+      max = 360,
+      bigStep = 1
+    },
+    -- Doesn't appear to work
+    circularTextureAuraRotation = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      name = L["Rotation"],
+      order = 14,
+      min = 0,
+      max = 360,
+      bigStep = 1
+    },
+  }
+
+  OptionsPrivate.commonOptions.ProgressOptionsForSubElement(parentData, data, options, 16)
+  OptionsPrivate.commonOptions.PositionOptionsForSubElement(data, options, 17, areaAnchors, pointAnchors)
+
+  OptionsPrivate.AddUpDownDeleteDuplicate(options, parentData, index, "subcirculartexture")
+
+  return options
+end
+
+  WeakAuras.RegisterSubRegionOptions("subcirculartexture", createOptions, L["Shows a Circular Progress Texture"]);

--- a/WeakAurasOptions/SubRegionOptions/LinearProgressTexture.lua
+++ b/WeakAurasOptions/SubRegionOptions/LinearProgressTexture.lua
@@ -1,0 +1,168 @@
+if not WeakAuras.IsLibsOK() then return end
+local AddonName = ...
+local OptionsPrivate = select(2, ...)
+
+local L = WeakAuras.L;
+
+local function createOptions(parentData, data, index, subIndex)
+  local pointAnchors = {}
+  local areaAnchors = {}
+  for child in OptionsPrivate.Private.TraverseLeafsOrAura(parentData) do
+    WeakAuras.Mixin(pointAnchors, OptionsPrivate.Private.GetAnchorsForData(child, "point"))
+    WeakAuras.Mixin(areaAnchors, OptionsPrivate.Private.GetAnchorsForData(child, "area"))
+  end
+
+  local options = {
+    __title = L["Linear Texture %s"]:format(subIndex),
+    __order = 1,
+    linearTextureVisible = {
+      type = "toggle",
+      width = WeakAuras.doubleWidth,
+      name = L["Show Linear Texture"],
+      order = 1,
+    },
+    linearTextureTexture = {
+      type = "input",
+      width = WeakAuras.doubleWidth - 0.15,
+      name = L["Texture"],
+      order = 2,
+    },
+    chooseTexture = {
+      type = "execute",
+      width = 0.15,
+      name = L["Choose"],
+      order = 3,
+      func = function()
+        local path = { "subRegions", index }
+        local paths = {}
+        for child in OptionsPrivate.Private.TraverseLeafsOrAura(parentData) do
+          paths[child.id] = path
+        end
+        OptionsPrivate.OpenTexturePicker(parentData, paths, {
+          texture = "linearTextureTexture",
+          color = "linearTextureColor",
+          blendMode = "linearTextureBlendMode"
+        }, OptionsPrivate.Private.texture_types)
+      end,
+      imageWidth = 24,
+      imageHeight = 24,
+      control = "WeakAurasIcon",
+      image = "Interface\\AddOns\\WeakAuras\\Media\\Textures\\browse",
+    },
+    linearTextureOrientation = {
+      type = "select",
+      width = WeakAuras.normalWidth,
+      name = L["Orientation"],
+      order = 4,
+      values = OptionsPrivate.Private.orientation_types
+    },
+    linearTextureInverse = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Inverse"],
+      order = 5.5,
+    },
+    linearTextureMirror = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Mirror"],
+      order = 6,
+    },
+    linearTextureDesaturate = {
+      type = "toggle",
+      width = WeakAuras.normalWidth,
+      name = L["Desaturate"],
+      order = 7,
+    },
+    linearTextureColor = {
+      type = "color",
+      width = WeakAuras.normalWidth,
+      name = L["Color"],
+      hasAlpha = true,
+      order = 8,
+    },
+    linearTextureBlendMode = {
+      type = "select",
+      width = WeakAuras.normalWidth,
+      name = L["Blend Mode"],
+      order = 9,
+      values = OptionsPrivate.Private.blend_types
+    },
+    linearTextureUser_x = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      order = 11,
+      name = L["Re-center X"],
+      min = -0.5,
+      max = 0.5,
+      bigStep = 0.01,
+    },
+    linearTextureUser_y = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      order = 12,
+      name = L["Re-center Y"],
+      min = -0.5,
+      max = 0.5,
+      bigStep = 0.01,
+    },
+    linearTextureCrop_x = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      name = L["Crop X"],
+      order = 13,
+      min = 0,
+      softMax = 2,
+      bigStep = 0.01,
+      isPercent = true,
+    },
+    linearTextureCrop_y = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      name = L["Crop Y"],
+      order = 14,
+      min = 0,
+      softMax = 2,
+      bigStep = 0.01,
+      isPercent = true,
+    },
+    -- Doesn't appear to work
+    linearTextureRotation = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      name = L["Texture Rotation"],
+      desc = L["Uses Texture Coordinates to rotate the texture."],
+      order = 15,
+      min = 0,
+      max = 360,
+      bigStep = 1
+    },
+    -- Doesn't appear to work
+    linearTextureAuraRotation = {
+      type = "range",
+      control = "WeakAurasSpinBox",
+      width = WeakAuras.normalWidth,
+      name = L["Rotation"],
+      order = 16,
+      min = 0,
+      max = 360,
+      bigStep = 1
+    },
+
+    -- Anchor Options added below
+  }
+
+  OptionsPrivate.commonOptions.ProgressOptionsForSubElement(parentData, data, options, 18)
+  OptionsPrivate.commonOptions.PositionOptionsForSubElement(data, options, 19, areaAnchors, pointAnchors)
+
+  OptionsPrivate.AddUpDownDeleteDuplicate(options, parentData, index, "sublineartexture")
+
+  return options
+end
+
+  WeakAuras.RegisterSubRegionOptions("sublineartexture", createOptions, L["Shows a Linear Progress Texture"]);

--- a/WeakAurasOptions/SubRegionOptions/Texture.lua
+++ b/WeakAurasOptions/SubRegionOptions/Texture.lua
@@ -44,7 +44,7 @@ local function createOptions(parentData, data, index, subIndex)
           color = "textureColor",
           mirror = "textureMirror",
           blendMode = "textureBlendMode"
-        }, OptionsPrivate.Private.texture_types, nil, true)
+        }, OptionsPrivate.Private.texture_types)
       end,
       imageWidth = 24,
       imageHeight = 24,

--- a/WeakAurasOptions/WeakAurasOptions.toc
+++ b/WeakAurasOptions/WeakAurasOptions.toc
@@ -42,6 +42,8 @@ SubRegionOptions\Tick.lua
 SubRegionOptions\Model.lua
 SubRegionOptions\StopMotion.lua
 SubRegionOptions\Texture.lua
+SubRegionOptions\CircularProgressTexture.lua
+SubRegionOptions\LinearProgressTexture.lua
 
 Cache.lua
 


### PR DESCRIPTION
By heavily refactoring progress textures.

Not every feature of ProgressTexture is supported by these sub elements,
missing ones can be added later.