### PR TITLE
GenericTrigger: fix regex for weapon enchants

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -3358,7 +3358,7 @@ do
           if(v:GetObjectType() == "FontString") then
             local text = v:GetText();
             if(text) then
-              local _, _, name, shortenedName = text:find("^((.-) ?+?[VI%d]*) %(%d+ .+%)$");
+              local _, _, name, shortenedName = text:find("^((.-) ?+?[XVI%d]*) %(%d+ .+%)$");
               if(name) then
                 return name, shortenedName;
               end


### PR DESCRIPTION
This fixes the regex to get the short weapon enchantment name without the roman numeric postfix (e.g. Deadly Poison IX (item=43233) or Instant Poison IX (item=43231))